### PR TITLE
ggml-qnn: refine code and keep sync ggml-qnn.cpp&ggml-qnn.h between local and PR in upstream

### DIFF
--- a/cdeosplayer/cdeosplayer-lib/src/main/java/cdeos/media/player/CDEUtils.java
+++ b/cdeosplayer/cdeosplayer-lib/src/main/java/cdeos/media/player/CDEUtils.java
@@ -4054,7 +4054,7 @@
      //keep sync with ggml-qnn.h
      public static final int QNN_BACKEND_CPU           = 0;
      public static final int QNN_BACKEND_GPU           = 1;
-     public static final int QNN_BACKEND_HTP           = 2;
+     public static final int QNN_BACKEND_NPU           = 2; //aka HTP/DSP
      public static final int QNN_BACKEND_GGML          = 3; //"fake" QNN backend, just for compare performance between QNN and original GGML
 
 

--- a/cdeosplayer/kantv/src/main/java/com/cdeos/kantv/app/IApplication.java
+++ b/cdeosplayer/kantv/src/main/java/com/cdeos/kantv/app/IApplication.java
@@ -168,7 +168,7 @@ public class IApplication extends Application {
     public void initGlobal() {
         long startTime = System.currentTimeMillis();
         String buildTime = BuildConfig.BUILD_TIME;
-        CDEUtils.setReleaseMode(true);
+        CDEUtils.setReleaseMode(false);
         CDELog.j(TAG, "*************************enter initGlobal *********************************");
         CDELog.j(TAG, "buildTime: " + buildTime);
         CDELog.j(TAG, "init app");
@@ -263,9 +263,9 @@ public class IApplication extends Application {
         CDEAssetLoader.copyAssetDir(mContext, "qnnlib", CDEUtils.getDataPath(mContext) + "qnnlib");
         CDELog.j(TAG, "qnn lib path:" + CDEUtils.getDataPath(mContext) + "qnnlib");
 
-        //TIP: move assets/models to /sdcard/kantv/models manually
+        //note: move assets/models to /sdcard/kantv/models manually
         //     for purpose of reduce size of APK, the APK size would be smaller significantly
-
+        CDEAssetLoader.copyAssetDir(mContext, "models", CDEUtils.getDataPath() + "/models");
 
         //step-4:
         String configString = CDEAssetLoader.readTextFromFile(CDEAssetLoader.getDataPath(mContext) + "config.json");

--- a/cdeosplayer/kantv/src/main/java/com/cdeos/kantv/ui/fragment/AIResearchFragment.java
+++ b/cdeosplayer/kantv/src/main/java/com/cdeos/kantv/ui/fragment/AIResearchFragment.java
@@ -516,7 +516,7 @@
              if (isNCNNInference()) {
                  //inference using NCNN framework
 
-                 if (backendIndex == CDEUtils.QNN_BACKEND_HTP) {
+                 if (backendIndex == CDEUtils.QNN_BACKEND_NPU) {
                      CDEUtils.showMsgBox(mActivity, "NCNN inference with NPU backend not supported currently");
                      return;
                  }

--- a/core/ggml/CMakeLists.txt
+++ b/core/ggml/CMakeLists.txt
@@ -11,8 +11,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(TARGET_XIAOMI14    OFF)  # set it to ON to get much better performance on Xiaomi 14 or Qualcomm Snapdragon 8 Gen 3 SoC based Android phone
-set(GGML_ENABLE_QNN    OFF)  # set it to ON to enable QNN(Qualcomm Neural Network, aka Qualcomm AI Engine Direct) SDK on Qualcomm SoC based Android phone
+set(TARGET_XIAOMI14    ON)  # set it to ON to get much better performance on Xiaomi 14 or Qualcomm Snapdragon 8 Gen 3 SoC based Android phone
+set(GGML_ENABLE_QNN    ON)  # set it to ON to enable QNN(Qualcomm Neural Network, aka Qualcomm AI Engine Direct) SDK on Qualcomm SoC based Android phone
 
 set(GGML_SRC_DIR                ${CMAKE_SOURCE_DIR}/ggml)
 

--- a/core/ggml/jni/ggml-jni-impl-external.cpp
+++ b/core/ggml/jni/ggml-jni-impl-external.cpp
@@ -7287,15 +7287,15 @@ int qnn_matrix(int n_backend_type, int n_op_type) {
                     n_backend_type, get_qnn_backend_name(n_backend_type), n_op_type);
 
     switch (n_backend_type) {
-        case QNN_CPU:
+        case QNN_BACKEND_CPU:
             qnn_backend_lib = "libQnnCpu.so";
             break;
 
-        case QNN_GPU:
+        case QNN_BACKEND_GPU:
             qnn_backend_lib = "libQnnGpu.so";
             break;
 
-        case QNN_HTP: {
+        case QNN_BACKEND_NPU: {
             qnn_backend_lib = "libQnnHtp.so";
             std::string path = "/data/data/com.cdeos.kantv/qnnlib/";
             LOGGI("path:%s\n", path.c_str());
@@ -7480,7 +7480,7 @@ int qnn_matrix(int n_backend_type, int n_op_type) {
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, &tensor_2);
         LOGGI("error = %d\n", error);
 
-        if (QNN_HTP == n_backend_type) {
+        if (QNN_BACKEND_NPU == n_backend_type) {
             qnn_buffer_0 = static_cast<uint8_t *>(qnn_backend.alloc_rpcmem(128, 4));
             if (nullptr == qnn_buffer_0) {
                 LOGGW("alloc rpcmem failure, %s\n", strerror(errno));
@@ -7585,7 +7585,7 @@ int qnn_matrix(int n_backend_type, int n_op_type) {
                 GGML_JNI_NOTIFY("output matrix:");
                 for (size_t i = 0; i < 1; i++) {
                     float * temp = nullptr;
-                    if (QNN_HTP == n_backend_type)
+                    if (QNN_BACKEND_NPU == n_backend_type)
                         temp = (float*)qnn_buffer_2;
                     else
                         temp = output_matrix[i];
@@ -8419,10 +8419,10 @@ int qnn_complex_graph(int n_backend_type, int n_graph_type) {
                     n_backend_type, get_qnn_backend_name(n_backend_type), n_graph_type);
 
     switch (n_graph_type) {
-        case 0: // MNIST手写数字识别推理, https://github.com/StudyingLover/ggml-tutorial
+        case 0: // MNIST CV inference of digital number, https://github.com/StudyingLover/ggml-tutorial
         {
             GGML_JNI_NOTIFY("input data is mnist-5.png\n");
-            mnist_inference("/sdcard/kantv/mnist-ggml-model-f32.gguf", "/sdcard/kantv/mnist-5.png", 0, 4, GGML_BACKEND_GGML);
+            mnist_inference("/sdcard/kantv/mnist-ggml-model-f32.gguf", "/sdcard/kantv/mnist-5.png", 0, 4, QNN_BACKEND_GGML);
             break;
         }
         case 1:

--- a/core/ggml/jni/ggml-jni-impl.cpp
+++ b/core/ggml/jni/ggml-jni-impl.cpp
@@ -636,7 +636,7 @@ static const char * ggml_jni_transcribe_from_file(const char * sz_model_path, co
         struct whisper_context_params wcp = whisper_context_default_params();
         LOGGD("backend %d", n_backend_type);
         wcp.gpu_device  = n_backend_type;//added on 04-17-2024, for PoC:Add Qualcomm mobile SoC native backend for GGML, https://github.com/zhouwg/kantv/issues/121
-        if (n_backend_type != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
+        if (n_backend_type != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;
@@ -827,9 +827,9 @@ void ggml_jni_bench(const char * sz_model_path, const char * sz_user_data, int n
     LOGGD("bench type:%d\n", n_bench_type);
     LOGGD("backend type:%d\n", n_backend_type);
     LOGGD("op type:%d\n", n_op_type);
-    if (GGML_BACKEND_GGML == n_backend_type) {
+    if (QNN_BACKEND_GGML == n_backend_type) {
         p_asr_ctx->b_use_gpu = false;
-        p_asr_ctx->gpu_device = GGML_BACKEND_GGML;// GGML_BACKEND_GGML is a fake QNN backend, just used for compare performance between QNN backend and original ggml
+        p_asr_ctx->gpu_device = QNN_BACKEND_GGML;// QNN_BACKEND_GGML is a fake QNN backend, just used for compare performance between QNN backend and original ggml
     } else {
 #ifdef GGML_USE_QNN
         p_asr_ctx->b_use_gpu = true;
@@ -1530,7 +1530,7 @@ int whisper_asr_init(const char * sz_model_path, int n_threads, int n_asrmode, i
      // the user could specify to use devices cpu, sycl_igpu0 and sycl_dgpu0 to select CPU, iGPU and dGPU
      //c_params.gpu_device    = QNN_HTP;//TODO:Failed in loading stub: dlopen failed: library "libQnnHtpV66Stub.so" not found
      c_params.gpu_device  = n_backend;
-     if (n_backend != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
+     if (n_backend != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
          c_params.use_gpu = true;
      } else {
          c_params.use_gpu = false;
@@ -1715,7 +1715,7 @@ int whisper_asr_reset(const char * sz_model_path, int n_threads, int n_asrmode, 
         }
         struct whisper_context_params wcp = whisper_context_default_params();
         wcp.gpu_device  = n_backend;//added on 04-17-2024, for PoC:Add Qualcomm mobile SoC native backend for GGML, https://github.com/zhouwg/kantv/issues/121
-        if (n_backend != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
+        if (n_backend != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is a fake QNN backend, just used to compare performance between QNN backend and original GGML
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;
@@ -1730,7 +1730,7 @@ int whisper_asr_reset(const char * sz_model_path, int n_threads, int n_asrmode, 
         }
         struct whisper_context_params wcp = whisper_context_default_params();
         wcp.gpu_device  = n_backend;//added on 04-17-2024, for PoC:Add Qualcomm mobile SoC native backend for GGML, https://github.com/zhouwg/kantv/issues/121
-        if (n_backend != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is a "fake" QNN backend, just used to compare performance between QNN backend and original GGML
+        if (n_backend != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is a "fake" QNN backend, just used to compare performance between QNN backend and original GGML
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;

--- a/core/ggml/jni/ggml-jni.c
+++ b/core/ggml/jni/ggml-jni.c
@@ -84,7 +84,7 @@ Java_org_ggml_ggmljava_ggml_1bench(JNIEnv *env, jclass clazz, jstring model_path
         goto failure;
     }
 
-    if (backend_type >= GGML_BACKEND_MAX) {
+    if (backend_type > QNN_BACKEND_GGML) {
         LOGGW("pls check backend type\n");
         goto failure;
     }
@@ -331,7 +331,7 @@ Java_org_ggml_ggmljava_ggml_1bench_1m(JNIEnv *env, jclass clazz, jstring model_p
         goto failure;
     }
 
-    if (n_backend_type >= GGML_BACKEND_MAX) {
+    if (n_backend_type > QNN_BACKEND_GGML) {
         GGML_JNI_NOTIFY("[%s,%s,%d]pls check backend type", __FILE__, __FUNCTION__, __LINE__);
         goto failure;
     }

--- a/core/ggml/jni/ggml-jni.h
+++ b/core/ggml/jni/ggml-jni.h
@@ -30,6 +30,7 @@
 #endif
 
 #include "ggml.h"
+#include "ggml-qnn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,15 +55,16 @@ enum ggml_jni_bench_type {
     GGML_BENCHMARK_MAX
 };
 
-
+#if 0 //remove it sine v1.3.11 to avoid confusion/duplication between ggml-jni.h and ggml-qnn.h
 // available backend for ggml-jni
 enum ggml_jni_backend_type {
     GGML_BACKEND_CPU = 0,
     GGML_BACKEND_GPU,
-    GGML_BACKEND_DSP,
+    GGML_BACKEND_NPU,  // aka HTP/DSP
     GGML_BACKEND_GGML, //"fake" QNN backend just for compare performance between QNN and original GGML
     GGML_BACKEND_MAX
 };
+#endif
 //=============================================================================================
 
 

--- a/core/ggml/jni/llm-inference.cpp
+++ b/core/ggml/jni/llm-inference.cpp
@@ -130,7 +130,7 @@ int llama_inference_main(int argc, char ** argv, int backend) {
     }
     llama_sampling_params & sparams = params.sparams;
 
-    if (backend != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is the original GGML, used to compare performance between QNN backend and original GGML
+    if (backend != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is the original GGML, used to compare performance between QNN backend and original GGML
 #ifdef GGML_USE_QNN
         LOGGD("using QNN backend %d", backend);
         params.main_gpu = backend;

--- a/core/ggml/jni/minicpmv-cli.cpp
+++ b/core/ggml/jni/minicpmv-cli.cpp
@@ -95,7 +95,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 #ifdef ANDROID
-    if (backend != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is the original GGML, used to compare performance between QNN backend and original GGML
+    if (backend != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is the original GGML, used to compare performance between QNN backend and original GGML
 #ifdef GGML_USE_QNN
         LOGGD("using QNN backend %d", backend);
         params.main_gpu = backend;

--- a/core/ggml/llamacpp/ggml-qnn.cpp
+++ b/core/ggml/llamacpp/ggml-qnn.cpp
@@ -1,3 +1,7 @@
+#define NOT_IN_PR   1
+
+
+#if NOT_IN_PR
 /*
  * Copyright (c) 2024- KanTV Authors
  *
@@ -15,18 +19,16 @@
  *
  * todo:
  *
- * 1. lack of implementation of other GGML-OPs using QNN API(only support GGML_OP_MUL_MAT,
- *    GGML_OP_MUL, GGML_OP_ADD, would be done by community in upstream GGML community)
+ * 1. lack of implementation of other GGML OPs using QNN API(only support GGML_OP_MUL_MAT,
+ *    GGML_OP_MUL, GGML_OP_ADD currently), would be done in upstream GGML community
  *
- * 2. only support FP32 / FP16 (other data type not used currently, would be done by community in upstream GGML community)
+ * 2. only support FP32 / FP16, other(quantized) GGML data type not used currently, data type of
+ *    input tensor and output tensor must be same(this is a real big limitation in this backend).
+ *    would be done in upstream GGML community
  *
- * 3. data type of input tensors and output tensor must be same(this is a big limitation)
+ * 3. QNN's RPC feature(which is required for QNN NPU backend) not used
  *
- * 4. QNN's RPC feature(which useful for QNN HTP(aka DSP) backend) not used
- *
- * 5. multi QNN backend(CPU/GPU/DSP) simultaneously not support
- *
- * 6. multithreading not work with QNN GPU/HTP(aka DSP) backend
+ * 4. performance fine-tune using QNN backend(mixed inference between CPU&GPU&NPU)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +42,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -91,23 +94,25 @@
 #include "ggml-qnn.h"
 
 #include "ggml-backend-impl.h"
+
+
 // =================================================================================================
 //
-//  forward/external declaration
+//  forward/external/helper declaration
 //
 // =================================================================================================
 class qnn_instance;
 
-//TODO: should be removed because this is a workaround method during development stage
-extern "C" void ggml_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor, struct ggml_compute_state * state);
 
-static void ggml_qnn_log_internal(ggml_log_level level, const char * file, const char * func, int line, const char * format, ...);
-
-#if (defined __ANDROID__) || (defined ANDROID) //Qualcomm's QNN could running on Windows over ARM(aka WoA)
+#if (defined __ANDROID__) || (defined ANDROID)
 extern "C" int __android_log_print(int prio, const char * tag, const char * fmt, ...)
 __attribute__((__format__(printf, 3, 4)));
 #endif
+static void ggml_qnn_log_internal(ggml_log_level level, const char * file, const char * func, int line, const char * format, ...);
 
+#if 1// NOT_IN_PR //should be removed before PR because this is a workaround method during development stage
+extern "C" void ggml_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor, struct ggml_compute_state * state);
+#endif
 
 
 // =================================================================================================
@@ -127,10 +132,9 @@ __attribute__((__format__(printf, 3, 4)));
 #define BUF_MAJOR_MASK                                  0xFF000000
 #define BUF_CONTROL_BASE                                0xEE000000
 
-#define GGML_QNN_DEBUG                                  0
-#define GGML_QNN_TRACE                                  0
+#define GGML_QNN_DEBUG                                  1
 
-#define QNN_LOG_ERROR(...) ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define QNN_LOG_ERROR(...) ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG,  __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define QNN_LOG_WARN(...)  ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define QNN_LOG_INFO(...)  ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG , __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 
@@ -138,18 +142,6 @@ __attribute__((__format__(printf, 3, 4)));
 #define QNN_LOG_DEBUG(...) ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #else
 #define QNN_LOG_DEBUG(...)
-#endif
-
-#if GGML_QNN_TRACE
-#define ENTER_FUNC()       ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG, __FILE__, __FUNCTION__, __LINE__, "enter %s", __FUNCTION__)
-
-#define LEAVE_FUNC()       ggml_qnn_log_internal(GGML_LOG_LEVEL_DEBUG, __FILE__, __FUNCTION__, __LINE__, "leave %s", __FUNCTION__)
-
-#else
-
-#define ENTER_FUNC()
-
-#define LEAVE_FUNC()
 #endif
 
 
@@ -164,33 +156,33 @@ __attribute__((__format__(printf, 3, 4)));
 
 #define VALIDATE_TENSOR_VERSION(tensor, err)            VALIDATE(validate_tensor_version(tensor), err)
 
-#define VALIDATE_OP_CONFIG_VERSION(op, err)             VALIDATE(validate_opconfig_version(op), err)
+#define VALIDATE_OP_CONFIG_VERSION(op, err)             VALIDATE(validate_op_config_version(op), err)
 
 #define QNN_VER_PTR(x)                                  (&((x).v1))
-#define QNN_OP_CFG_VALID(opConfig)                      ((opConfig).version == QNN_OPCONFIG_VERSION_1)
+#define QNN_OP_CFG_VALID(op_config)                      ((op_config).version == QNN_OPCONFIG_VERSION_1)
 
-#define QNN_OP_CFG_GET_NAME(opConfig)                   get_qnn_oponfig_name(opConfig)
-#define QNN_OP_CFG_GET_PACKAGE_NAME(opConfig)           get_qnn_opconfig_packagename(opConfig)
-#define QNN_OP_CFG_GET_TYPE_NAME(opConfig)              get_qnn_opconfig_typename(opConfig)
-#define QNN_OP_CFG_GET_NUM_PARAMS(opConfig)             get_qnn_opconfig_numparams(opConfig)
-#define QNN_OP_CFG_GET_PARAMS(opConfig)                 get_qnn_opconfig_params(opConfig)
-#define QNN_OP_CFG_GET_NUM_INPUTS(opConfig)             get_qnn_opconfig_numinputs(opConfig)
-#define QNN_OP_CFG_GET_INPUTS(opConfig)                 get_qnn_opconfig_inputs(opConfig)
-#define QNN_OP_CFG_GET_NUM_OUTPUTS(opConfig)            get_qnn_opconfig_numoutputs(opConfig)
-#define QNN_OP_CFG_GET_OUTPUTS(opConfig)                get_qnn_opconfig_outputs(opConfig)
+#define QNN_OP_CFG_GET_NAME(op_config)                   get_qnn_oponfig_name(op_config)
+#define QNN_OP_CFG_GET_PACKAGE_NAME(op_config)           get_qnn_op_config_packagename(op_config)
+#define QNN_OP_CFG_GET_TYPE_NAME(op_config)              get_qnn_op_config_typename(op_config)
+#define QNN_OP_CFG_GET_NUM_PARAMS(op_config)             get_qnn_op_config_numparams(op_config)
+#define QNN_OP_CFG_GET_PARAMS(op_config)                 get_qnn_op_config_params(op_config)
+#define QNN_OP_CFG_GET_NUM_INPUTS(op_config)             get_qnn_op_config_numinputs(op_config)
+#define QNN_OP_CFG_GET_INPUTS(op_config)                 get_qnn_op_config_inputs(op_config)
+#define QNN_OP_CFG_GET_NUM_OUTPUTS(op_config)            get_qnn_op_config_numoutputs(op_config)
+#define QNN_OP_CFG_GET_OUTPUTS(op_config)                get_qnn_op_config_outputs(op_config)
 
-#define QNN_OP_CFG_SET_NAME(opConfig, value)            set_qnn_opconfig_name(opConfig, value)
-#define QNN_OP_CFG_SET_PACKAGE_NAME(opConfig, value)    set_qnn_opconfig_packagename(opConfig, value)
-#define QNN_OP_CFG_SET_TYPE_NAME(opConfig, value)       set_qnn_opconfig_typename(opConfig, value)
+#define QNN_OP_CFG_SET_NAME(op_config, value)            set_qnn_op_config_name(op_config, value)
+#define QNN_OP_CFG_SET_PACKAGE_NAME(op_config, value)    set_qnn_op_config_packagename(op_config, value)
+#define QNN_OP_CFG_SET_TYPE_NAME(op_config, value)       set_qnn_op_config_typename(op_config, value)
 
-#define QNN_OP_CFG_SET_PARAMS(opConfig, numOfParams, params) \
-  set_qnn_opconfig_params(opConfig, numOfParams, params)
+#define QNN_OP_CFG_SET_PARAMS(op_config, num_of_params, params) \
+  set_qnn_op_config_params(op_config, num_of_params, params)
 
-#define QNN_OP_CFG_SET_INPUTS(opConfig, numOfInputs, inputTensors) \
-  set_qnn_opconfig_inputs(opConfig, numOfInputs, inputTensors)
+#define QNN_OP_CFG_SET_INPUTS(op_config, num_of_inputs, inputTensors) \
+  set_qnn_op_config_inputs(op_config, num_of_inputs, inputTensors)
 
-#define QNN_OP_CFG_SET_OUTPUTS(opConfig, numOfOutputs, outputTensors) \
-  set_qnn_opconfig_outputs(opConfig, numOfOutputs, outputTensors)
+#define QNN_OP_CFG_SET_OUTPUTS(op_config, num_of_outputs, output_tensors) \
+  set_qnn_op_config_outputs(op_config, num_of_outputs, output_tensors)
 
 #define QNN_TENSOR_GET_ID(tensor)                       get_qnn_tensorid(tensor)
 #define QNN_TENSOR_GET_NAME(tensor)                     get_qnn_tensorname(tensor)
@@ -229,31 +221,31 @@ using _pfn_QnnInterface_getProviders                    = decltype(QnnInterface_
 using _pfn_QnnSystemInterface_getProviders              = decltype(QnnSystemInterface_getProviders);
 
 
-
-typedef struct qnn_buf_s qnn_buf_t;
-typedef struct qnn_buf_s qnn_buf_buffer_t;
-typedef struct buf_element_s buf_element_t;
-typedef void (*ggml_qnn_func_t)(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
-typedef void (*ggml_qnn_func_common_t)(const ggml_op ggmlop, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
+typedef void (* ggml_qnn_func_t)(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
+typedef void (* ggml_qnn_func_common_t)(const ggml_op ggml_op, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
 
 enum class ggml_qnn_profile_level {
-    profile_off = 0,
-    profile_basic = 1,
-    profile_detail = 2
+    profile_off     = 0,
+    profile_basic   = 1,
+    profile_detail  = 2
 };
 
 
+#if NOT_IN_PR
+typedef struct qnn_buf_s qnn_buf_t;
+typedef struct qnn_buf_s qnn_buf_buffer_t;
+typedef struct buf_element_s buf_element_t;
 struct buf_element_s {
-    buf_element_t        * next;
+    buf_element_t         * next;
 
-    unsigned char        * mem;
-    unsigned char        * content;   /* start of raw content in mem  */
+    unsigned char         * mem;
+    unsigned char         * content;   /* start of raw content in mem  */
 
     uint32_t              size ;      /* size of content  */
     int32_t               max_size;   /* size of pre-allocated memory pointed to by mem   */
     uint32_t              type;
-    void (*free_buffer) (buf_element_t * buf);
-    void                 * source;   /* CPU, GPU, DSP, ... */
+    void (* free_buffer) (buf_element_t * buf);
+    void                  * source;   /* CPU, GPU, NPU */
     int                   id;
 } ;
 
@@ -269,23 +261,23 @@ struct qnn_buf_s {
     pthread_mutex_t mutex;
     pthread_cond_t  not_empty;
 
-    void (*put) (qnn_buf_t * fifo, buf_element_t * buf);
+    void (* put) (qnn_buf_t * fifo, buf_element_t * buf);
 
-    buf_element_t *(*get) (qnn_buf_t * fifo);
+    buf_element_t * (* get) (qnn_buf_t * fifo);
 
-    void (*clear) (qnn_buf_t * fifo) ;
+    void (* clear) (qnn_buf_t * fifo) ;
 
-    int (*size) (qnn_buf_t * fifo);
+    int (* size) (qnn_buf_t * fifo);
 
-    int (*num_free) (qnn_buf_t * fifo);
+    int (* num_free) (qnn_buf_t * fifo);
 
-    uint32_t (*data_size) (qnn_buf_t * fifo);
+    uint32_t (* data_size) (qnn_buf_t * fifo);
 
-    void (*destroy) (qnn_buf_t * fifo);
+    void (* destroy) (qnn_buf_t * fifo);
 
-    buf_element_t * (*buffer_alloc) (qnn_buf_t * self);
+    buf_element_t * (* buffer_alloc) (qnn_buf_t * self);
 
-    buf_element_t * (*buffer_try_alloc) (qnn_buf_t * self);
+    buf_element_t * (* buffer_try_alloc) (qnn_buf_t * self);
 
     buf_element_t   * buffer_pool_top;
     pthread_mutex_t  buffer_pool_mutex;
@@ -295,7 +287,7 @@ struct qnn_buf_s {
     int              buffer_pool_buf_size;
     void            * buffer_pool_base; /* used to free mem pool */
 } ;
-
+#endif
 
 struct ggml_backend_qnn_context {
     int device;
@@ -303,7 +295,9 @@ struct ggml_backend_qnn_context {
     char name[GGML_MAX_NAME];
     char lib[GGML_MAX_NAME];
     qnn_instance * instance;
+#if NOT_IN_PR
     qnn_buf_t * buffer_pool;
+#endif
     struct ggml_backend * backend;
     QNN_INTERFACE_VER_TYPE raw_interface;
     QNN_SYSTEM_INTERFACE_VER_TYPE raw_system_interface;
@@ -315,11 +309,9 @@ struct ggml_backend_qnn_context {
 //  static global variables
 //
 // =================================================================================================
-//TODO: should be removed for support multi QNN backend simultaneously
 static ggml_backend_t g_qnn_backend = nullptr;
 
-//TODO: should be removed for support multi QNN backend simultaneously
-static int g_current_device        = 3; // 3 is the default ggml backend
+static int g_current_device        = QNN_BACKEND_GGML; // QNN_BACKEND_GGML is the default ggml backend
 
 static bool GGML_OP_HAS_INIT    [GGML_OP_COUNT] = { 0 };
 static bool GGML_OP_HAS_FINALIZE[GGML_OP_COUNT] = { 0 };
@@ -350,16 +342,20 @@ static void ggml_setup_op_has_task_pass(void) {
 }
 
 
-//use a prebuild static memory layout to avoid complex resource management, this method also used
-//in GGML internal or FFmpeg
-
-//QNN cDSP and HTA backend would not be used currently, just focus on QNN CPU/GPU/HTP(aka DSP) backend currently
+//QNN cDSP and HTA backend would not be used currently, just focus on QNN CPU/GPU/NPU(aka HTP/DSP) backend currently
+#if NOT_IN_PR
 static struct ggml_backend_qnn_context g_qnn_mgr[GGML_QNN_MAX_DEVICES] = {
-        [QNN_CPU]   = {.device = 0, .threads = 1, .name =   "qnn-cpu", .lib = "libQnnCpu.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
-        [QNN_GPU]   = {.device = 1, .threads = 1, .name =   "qnn-gpu", .lib = "libQnnGpu.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
-        [QNN_HTP]   = {.device = 2, .threads = 1, .name =   "qnn-htp(aka dsp)", .lib = "libQnnHtp.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+        [QNN_BACKEND_CPU]   = {.device = 0, .threads = 1, .name =   "qnn-cpu", .lib = "libQnnCpu.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+        [QNN_BACKEND_GPU]   = {.device = 1, .threads = 1, .name =   "qnn-gpu", .lib = "libQnnGpu.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+        [QNN_BACKEND_NPU]   = {.device = 2, .threads = 1, .name =   "qnn-npu(aka htp/dsp)", .lib = "libQnnHtp.so", .instance = nullptr, .buffer_pool = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
 };
-
+#else
+static struct ggml_backend_qnn_context g_qnn_mgr[GGML_QNN_MAX_DEVICES] = {
+        [QNN_BACKEND_CPU]   = {.device = 0, .threads = 1, .name =   "qnn-cpu", .lib = "libQnnCpu.so", .instance = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+        [QNN_BACKEND_GPU]   = {.device = 1, .threads = 1, .name =   "qnn-gpu", .lib = "libQnnGpu.so", .instance = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+        [QNN_BACKEND_NPU]   = {.device = 2, .threads = 1, .name =   "qnn-npu(aka htp/dsp)", .lib = "libQnnHtp.so", .instance = nullptr, .backend = nullptr, .raw_interface = nullptr, .raw_system_interface = nullptr},
+};
+#endif
 
 
 // =================================================================================================
@@ -369,7 +365,7 @@ static struct ggml_backend_qnn_context g_qnn_mgr[GGML_QNN_MAX_DEVICES] = {
 // =================================================================================================
 static inline int validate_tensor_version(Qnn_Tensor_t tensor) {
     if (tensor.version != QNN_TENSOR_VERSION_1) {
-        LOGGW("validate_tensor_version() tensor %s, got unsupported version %d\n",
+        QNN_LOG_WARN("validate_tensor_version() tensor %s, got unsupported version %d\n",
               tensor.v1.name,
               tensor.version);
         return 1;
@@ -378,218 +374,218 @@ static inline int validate_tensor_version(Qnn_Tensor_t tensor) {
 }
 
 
-static inline int validate_opconfig_version(Qnn_OpConfig_t opConfig) {
-    if (opConfig.version != QNN_OPCONFIG_VERSION_1) {
-        LOGGW("validate_opconfig_version() op %s, got unsupported version %d\n",
-              opConfig.v1.name,
-              opConfig.version);
+static inline int validate_op_config_version(Qnn_OpConfig_t op_config) {
+    if (op_config.version != QNN_OPCONFIG_VERSION_1) {
+        QNN_LOG_WARN("validate_op_config_version() op %s, got unsupported version %d\n",
+              op_config.v1.name,
+              op_config.version);
         return 1;
     }
     return 0;
 }
 
 
-static inline const char * get_qnn_oponfig_name(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.name;
+static inline const char * get_qnn_oponfig_name(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.name;
     }
     return nullptr;
 }
 
 
-static inline const char * get_qnn_oponfig_name(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_oponfig_name(*opConfig);
+static inline const char * get_qnn_oponfig_name(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_oponfig_name(*op_config);
 }
 
 
-static inline const char * get_qnn_opconfig_packagename(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.packageName;
+static inline const char * get_qnn_op_config_packagename(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.packageName;
     }
     return nullptr;
 }
 
 
-static inline const char * get_qnn_opconfig_packagename(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_packagename(*opConfig);
+static inline const char * get_qnn_op_config_packagename(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_packagename(*op_config);
 }
 
 
-static inline const char * get_qnn_opconfig_typename(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.typeName;
+static inline const char * get_qnn_op_config_typename(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.typeName;
     }
     return nullptr;
 }
 
 
-static inline const char * get_qnn_opconfig_typename(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_typename(*opConfig);
+static inline const char * get_qnn_op_config_typename(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_typename(*op_config);
 }
 
 
-static inline uint32_t get_qnn_opconfig_numparams(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.numOfParams;
+static inline uint32_t get_qnn_op_config_numparams(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.numOfParams;
     }
     return 0u;
 }
 
 
-static inline uint32_t get_qnn_opconfig_numparams(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_numparams(*opConfig);
+static inline uint32_t get_qnn_op_config_numparams(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_numparams(*op_config);
 }
 
 
-static inline const Qnn_Param_t * get_qnn_opconfig_params(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.params;
+static inline const Qnn_Param_t * get_qnn_op_config_params(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.params;
     }
     return nullptr;
 }
 
 
-static inline const Qnn_Param_t * get_qnn_opconfig_params(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_params(*opConfig);
+static inline const Qnn_Param_t * get_qnn_op_config_params(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_params(*op_config);
 }
 
 
-static inline uint32_t get_qnn_opconfig_numinputs(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.numOfInputs;
+static inline uint32_t get_qnn_op_config_numinputs(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.numOfInputs;
     }
     return 0u;
 }
 
 
-static inline uint32_t get_qnn_opconfig_numinputs(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_numinputs(*opConfig);
+static inline uint32_t get_qnn_op_config_numinputs(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_numinputs(*op_config);
 }
 
 
-static inline const Qnn_Tensor_t * get_qnn_opconfig_inputs(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.inputTensors;
+static inline const Qnn_Tensor_t * get_qnn_op_config_inputs(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.inputTensors;
     }
     return nullptr;
 }
 
 
-static inline const Qnn_Tensor_t * get_qnn_opconfig_inputs(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_inputs(*opConfig);
+static inline const Qnn_Tensor_t * get_qnn_op_config_inputs(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_inputs(*op_config);
 }
 
 
-static inline uint32_t get_qnn_opconfig_numoutputs(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.numOfOutputs;
+static inline uint32_t get_qnn_op_config_numoutputs(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.numOfOutputs;
     }
     return 0u;
 }
 
 
-static inline uint32_t get_qnn_opconfig_numoutputs(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_numoutputs(*opConfig);
+static inline uint32_t get_qnn_op_config_numoutputs(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_numoutputs(*op_config);
 }
 
 
-static inline const Qnn_Tensor_t * get_qnn_opconfig_outputs(const Qnn_OpConfig_t & opConfig) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        return opConfig.v1.outputTensors;
+static inline const Qnn_Tensor_t * get_qnn_op_config_outputs(const Qnn_OpConfig_t & op_config) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        return op_config.v1.outputTensors;
     }
     return nullptr;
 }
 
 
-static inline const Qnn_Tensor_t * get_qnn_opconfig_outputs(const Qnn_OpConfig_t * opConfig) {
-    return get_qnn_opconfig_outputs(*opConfig);
+static inline const Qnn_Tensor_t * get_qnn_op_config_outputs(const Qnn_OpConfig_t * op_config) {
+    return get_qnn_op_config_outputs(*op_config);
 }
 
 
-static inline void set_qnn_opconfig_name(Qnn_OpConfig_t & opConfig, const char * name) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.name = name;
+static inline void set_qnn_op_config_name(Qnn_OpConfig_t & op_config, const char * name) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.name = name;
     }
 }
 
 
-static inline void set_qnn_opconfig_name(Qnn_OpConfig_t * opConfig, const char * name) {
-    set_qnn_opconfig_name(*opConfig, name);
+static inline void set_qnn_op_config_name(Qnn_OpConfig_t * op_config, const char * name) {
+    set_qnn_op_config_name(*op_config, name);
 }
 
 
-static inline void set_qnn_opconfig_packagename(Qnn_OpConfig_t & opConfig, const char * packageName) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.packageName = packageName;
+static inline void set_qnn_op_config_packagename(Qnn_OpConfig_t & op_config, const char * packageName) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.packageName = packageName;
     }
 }
 
 
-static inline void set_qnn_opconfig_packagename(Qnn_OpConfig_t * opConfig, const char * packageName) {
-    set_qnn_opconfig_packagename(*opConfig, packageName);
+static inline void set_qnn_op_config_packagename(Qnn_OpConfig_t * op_config, const char * packageName) {
+    set_qnn_op_config_packagename(*op_config, packageName);
 }
 
 
-static inline void set_qnn_opconfig_typename(Qnn_OpConfig_t & opConfig, const char * typeName) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.typeName = typeName;
+static inline void set_qnn_op_config_typename(Qnn_OpConfig_t & op_config, const char * typeName) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.typeName = typeName;
     }
 }
 
 
-static inline void set_qnn_opconfig_typename(Qnn_OpConfig_t * opConfig, const char * typeName) {
-    set_qnn_opconfig_typename(*opConfig, typeName);
+static inline void set_qnn_op_config_typename(Qnn_OpConfig_t * op_config, const char * typeName) {
+    set_qnn_op_config_typename(*op_config, typeName);
 }
 
 
-static inline void set_qnn_opconfig_params(Qnn_OpConfig_t & opConfig,
-                                 uint32_t numOfParams,
+static inline void set_qnn_op_config_params(Qnn_OpConfig_t & op_config,
+                                 uint32_t num_of_params,
                                  Qnn_Param_t * params) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.numOfParams = numOfParams;
-        opConfig.v1.params      = params;
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.numOfParams = num_of_params;
+        op_config.v1.params      = params;
     }
 }
 
 
-static inline void set_qnn_opconfig_params(Qnn_OpConfig_t * opConfig,
-                                 uint32_t numOfParams,
+static inline void set_qnn_op_config_params(Qnn_OpConfig_t * op_config,
+                                 uint32_t num_of_params,
                                  Qnn_Param_t * params) {
-    set_qnn_opconfig_params(*opConfig, numOfParams, params);
+    set_qnn_op_config_params(*op_config, num_of_params, params);
 }
 
 
-static inline void set_qnn_opconfig_inputs(Qnn_OpConfig_t & opConfig,
-                                 uint32_t numOfInputs,
+static inline void set_qnn_op_config_inputs(Qnn_OpConfig_t & op_config,
+                                 uint32_t num_of_inputs,
                                  Qnn_Tensor_t * inputTensors) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.numOfInputs  = numOfInputs;
-        opConfig.v1.inputTensors = inputTensors;
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.numOfInputs  = num_of_inputs;
+        op_config.v1.inputTensors = inputTensors;
     }
 }
 
 
-static inline void set_qnn_opconfig_inputs(Qnn_OpConfig_t * opConfig,
-                                 uint32_t numOfInputs,
+static inline void set_qnn_op_config_inputs(Qnn_OpConfig_t * op_config,
+                                 uint32_t num_of_inputs,
                                  Qnn_Tensor_t * inputTensors) {
-    set_qnn_opconfig_inputs(*opConfig, numOfInputs, inputTensors);
+    set_qnn_op_config_inputs(*op_config, num_of_inputs, inputTensors);
 }
 
 
-static inline void set_qnn_opconfig_outputs(Qnn_OpConfig_t & opConfig,
-                                  uint32_t numOfOutputs,
-                                  Qnn_Tensor_t * outputTensors) {
-    if (opConfig.version == QNN_OPCONFIG_VERSION_1) {
-        opConfig.v1.numOfOutputs  = numOfOutputs;
-        opConfig.v1.outputTensors = outputTensors;
+static inline void set_qnn_op_config_outputs(Qnn_OpConfig_t & op_config,
+                                  uint32_t num_of_outputs,
+                                  Qnn_Tensor_t * output_tensors) {
+    if (op_config.version == QNN_OPCONFIG_VERSION_1) {
+        op_config.v1.numOfOutputs  = num_of_outputs;
+        op_config.v1.outputTensors = output_tensors;
     }
 }
 
 
-static inline void set_qnn_opconfig_outputs(Qnn_OpConfig_t * opConfig,
-                                  uint32_t numOfOutputs,
-                                  Qnn_Tensor_t * outputTensors) {
-    set_qnn_opconfig_outputs(*opConfig, numOfOutputs, outputTensors);
+static inline void set_qnn_op_config_outputs(Qnn_OpConfig_t * op_config,
+                                  uint32_t num_of_outputs,
+                                  Qnn_Tensor_t * output_tensors) {
+    set_qnn_op_config_outputs(*op_config, num_of_outputs, output_tensors);
 }
 
 
@@ -864,7 +860,7 @@ static inline void set_qnn_tensor_memhandle(Qnn_Tensor_t * tensor, Qnn_MemHandle
 
 
 static size_t memscpy(void * dst, size_t dstSize, const void * src, size_t copySize) {
-    if (!dst || !src || !dstSize || !copySize) 
+    if (!dst || !src || !dstSize || !copySize)
         return 0;
 
     size_t minSize = dstSize < copySize ? dstSize : copySize;
@@ -876,7 +872,7 @@ static size_t memscpy(void * dst, size_t dstSize, const void * src, size_t copyS
 
 
 static char * ggml_qnn_strndup(const char * source, size_t maxlen) {
-    return ::strndup(source, maxlen); 
+    return ::strndup(source, maxlen);
 }
 
 
@@ -944,15 +940,13 @@ static int deep_copy_qnn_tensors(Qnn_Tensor_t & src, Qnn_Tensor_t & dst) {
 
     // need to allocate and copy memory for all the pointer members
     uint32_t rank = QNN_TENSOR_GET_RANK(src);
-    //LOGGD("QNN tensor rank %d", rank);
     QNN_TENSOR_SET_RANK(dst, rank);
     size_t dim_size       = rank * sizeof(uint32_t);
     uint32_t * dimensions = (uint32_t *)malloc(dim_size);
     if (dimensions == nullptr) {
-        LOGGW("deep_copy_qnn_tensors() allocation error while copying tensor %s\n", QNN_TENSOR_GET_NAME(src));
+        QNN_LOG_WARN("deep_copy_qnn_tensors() allocation error while copying tensor %s\n", QNN_TENSOR_GET_NAME(src));
         return 1;
     }
-    //LOGGD("%p", dimensions);
     memscpy(dimensions, dim_size, QNN_TENSOR_GET_DIMENSIONS(src), dim_size);
     QNN_TENSOR_SET_DIMENSIONS(dst, dimensions);
 
@@ -961,85 +955,37 @@ static int deep_copy_qnn_tensors(Qnn_Tensor_t & src, Qnn_Tensor_t & dst) {
 
 
 static int free_qnn_tensor(Qnn_Tensor_t & tensor) {
-    //ENTER_FUNC();
     int err = 0;
     VALIDATE_TENSOR_VERSION(tensor, err);
 
-    //LOGGD("here");
     if (nullptr == QNN_TENSOR_GET_NAME(tensor)) {
-        LOGGI("it should not happen, pls check");
+        QNN_LOG_INFO("it should not happen, pls check");
     } else {
-        //LOGGD("QNN tensor name %s", QNN_TENSOR_GET_NAME(tensor));
+        //QNN_LOG_DEBUG("QNN tensor name %s", QNN_TENSOR_GET_NAME(tensor));
         free((void *) QNN_TENSOR_GET_NAME(tensor));
     }
-    //LOGGD("here");
     if (nullptr == QNN_TENSOR_GET_DIMENSIONS(tensor)) {
-        LOGGI("it should not happen, pls check");
+        QNN_LOG_INFO("it should not happen, pls check");
     } else {
-        //LOGGD("%p", QNN_TENSOR_GET_DIMENSIONS(tensor));
         //TODO:why crash in here? why pointer changed with mul_mat?
         //memory leak after comment below line
         //free(QNN_TENSOR_GET_DIMENSIONS(tensor));
     }
-    //LEAVE_FUNC();
 
     return err;
 }
 
 
-static int free_qnn_tensors(Qnn_Tensor_t *& tensors, uint32_t numTensors) {
+static int free_qnn_tensors(Qnn_Tensor_t *& tensors, uint32_t num_tensors) {
     int err = 0;
 
     // free all pointer allocations in struct
-    for (size_t i = 0; i < numTensors; i++) {
+    for (size_t i = 0; i < num_tensors; i++) {
         free_qnn_tensor(tensors[i]);
     }
     free(tensors);
 
     return err;
-}
-
-
-static float ggml_tensor_sum_elements(const ggml_tensor * tensor) {
-    double sum = 0;
-    float  value = 0;
-    std::ostringstream tmposs;
-    if (tensor->type == GGML_TYPE_F32) {
-        for (int h = 0; h < tensor->ne[3]; h++) {
-            for (int i = 0; i < tensor->ne[2]; i++) {
-                for (int j = 0; j < tensor->ne[1]; j++) {
-                    for (int k = 0; k < tensor->ne[0]; k++) {
-                        value = ((float *) tensor->data)[h * tensor->ne[2] + i * tensor->ne[1] + j * tensor->ne[0] + k];
-                        sum += value;
-                        //LOGGD("[%d][%d][%d][%d]%.2f \t", h, i, j, k, value);
-                        tmposs << std::setw(8) << std::fixed << std::setprecision(2) << value << "\t";
-                    }
-                    if (strlen(tmposs.str().c_str()) > 4000) {
-
-                    } else {
-                        LOGGD("%s", tmposs.str().c_str());
-                    }
-                    tmposs.clear();
-                    tmposs.str("");
-                    LOGGD("\n");
-                }
-            }
-        }
-    }
-    LOGGD("\n");
-    return sum;
-}
-
-
-static void ggml_dump_tensor(const ggml_tensor * tensor, const char * name) {
-    LOGGD("dump ggml tensor %s\n", name);
-    LOGGD("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n", name,
-          tensor->type, ggml_type_name(tensor->type),
-          tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->nb[0], tensor->nb[1], tensor->nb[2]);
-    float sum = ggml_tensor_sum_elements(tensor);
-
-    //LOGGD("\n");
-    //LOGGD("Sum of tensor %s is %6.2f\n", name, sum);
 }
 
 
@@ -1054,74 +1000,21 @@ static uint32_t ggml_get_tensor_rank(const ggml_tensor * tensor) {
 }
 
 
-//TODO:
+//TODO: mapping more ggml data type to QNN data type
 //ref:explanation of k-quants, https://github.com/ggerganov/llama.cpp/pull/1684
 static Qnn_DataType_t qnn_datatype_from_ggml_datatype(enum ggml_type ggmltype) {
     switch (ggmltype) {
-        case GGML_TYPE_Q4_0:
-            return QNN_DATATYPE_UFIXED_POINT_4;
-        case GGML_TYPE_Q4_1:
-            return QNN_DATATYPE_SFIXED_POINT_4;
-        case GGML_TYPE_Q8_0:
-            return QNN_DATATYPE_UFIXED_POINT_8;
-        case GGML_TYPE_Q8_1:
-            return QNN_DATATYPE_SFIXED_POINT_8;
         case GGML_TYPE_F16:
             return QNN_DATATYPE_FLOAT_16;
         case GGML_TYPE_F32:
             return QNN_DATATYPE_FLOAT_32;
 
     }
-    return QNN_DATATYPE_FLOAT_32;
+    return QNN_DATATYPE_UNDEFINED;
 }
 
 
-static uint32_t qnn_datatype_size(Qnn_DataType_t data_type) {
-    switch (data_type) {
-        case QNN_DATATYPE_INT_8:
-        case QNN_DATATYPE_UINT_8:
-        case QNN_DATATYPE_SFIXED_POINT_8:
-        case QNN_DATATYPE_UFIXED_POINT_8:
-        case QNN_DATATYPE_BOOL_8:
-            return 1;
-        case QNN_DATATYPE_INT_16:
-        case QNN_DATATYPE_UINT_16:
-        case QNN_DATATYPE_FLOAT_16:
-        case QNN_DATATYPE_SFIXED_POINT_16:
-        case QNN_DATATYPE_UFIXED_POINT_16:
-            return 2;
-        case QNN_DATATYPE_INT_32:
-        case QNN_DATATYPE_UINT_32:
-        case QNN_DATATYPE_FLOAT_32:
-        case QNN_DATATYPE_SFIXED_POINT_32:
-        case QNN_DATATYPE_UFIXED_POINT_32:
-            return 4;
-        case QNN_DATATYPE_INT_64:
-        case QNN_DATATYPE_UINT_64:
-            return 8;
-        default:
-            LOGGD("wrong data type: %d\n", static_cast<int>(data_type));
-            return 0;
-    }
-}
-
-
-static std::string qnn_tensortype_to_string(const Qnn_TensorType_t type) {
-    switch (type) {
-        case QNN_TENSOR_TYPE_APP_WRITE: return "QNN_TENSOR_TYPE_APP_WRITE";
-        case QNN_TENSOR_TYPE_APP_READ: return "QNN_TENSOR_TYPE_APP_READ";
-        case QNN_TENSOR_TYPE_APP_READWRITE: return "QNN_TENSOR_TYPE_APP_READWRITE";
-        case QNN_TENSOR_TYPE_NATIVE: return "QNN_TENSOR_TYPE_NATIVE";
-        case QNN_TENSOR_TYPE_STATIC: return "QNN_TENSOR_TYPE_STATIC";
-        case QNN_TENSOR_TYPE_NULL: return "QNN_TENSOR_TYPE_NULL";
-        case QNN_TENSOR_TYPE_UNDEFINED: return "QNN_TENSOR_TYPE_UNDEFINED";
-        default: return std::string("UNKNOWN: ") + std::to_string(static_cast<int>(type));
-    }
-}
-
-
-
-//TODO:
+//TODO: only support GGML_OP_ADD/GGML_OP_MUL/GGML_OP_MUL_MAT
 static const char * qnn_opname_from_ggmlop(enum ggml_op ggmlop) {
     switch (ggmlop) {
         case GGML_OP_ADD:
@@ -1135,6 +1028,7 @@ static const char * qnn_opname_from_ggmlop(enum ggml_op ggmlop) {
     return nullptr;
 }
 
+
 static uint32_t ggml_get_tensor_data_size(const ggml_tensor * tensor) {
     /*
     size_t data_size = ggml_row_size(tensor->type, tensor->ne[0]);
@@ -1144,7 +1038,7 @@ static uint32_t ggml_get_tensor_data_size(const ggml_tensor * tensor) {
     }
 
     return data_size;
-     */
+    */
     return ggml_nbytes(tensor);
 }
 
@@ -1170,7 +1064,7 @@ static void * qnn_xmalloc(size_t size) {
         size++;
 
     if ((ptr = calloc(1, size)) == nullptr) {
-        LOGGW("malloc(%d) failed: %s\n",size, strerror(errno));
+        QNN_LOG_WARN("malloc(%d) failed: %s\n",size, strerror(errno));
         return nullptr;
     }
 
@@ -1189,7 +1083,7 @@ static void * qnn_xmalloc_aligned(size_t alignment, size_t size, void ** base) {
     return ptr;
 }
 
-
+#if NOT_IN_PR
 static void buffer_pool_free (buf_element_t * element) {
     qnn_buf_t * self = (qnn_buf_t *) element->source;
 
@@ -1200,7 +1094,7 @@ static void buffer_pool_free (buf_element_t * element) {
 
     self->buffer_pool_num_free++;
     if (self->buffer_pool_num_free > self->buffer_pool_capacity) {
-        LOGGD("TOO MANY FREE\n");
+        QNN_LOG_DEBUG("TOO MANY FREE\n");
     }
 
     pthread_cond_signal (&self->buffer_pool_cond_not_empty);
@@ -1270,7 +1164,6 @@ static void qnn_buf_buffer_put(qnn_buf_t * fifo, buf_element_t * element) {
     fifo->qnn_buf_size++;
     fifo->qnn_buf_data_size += element->size;
 
-    LOGJ("put:index %d, fifo->size is %d, self->buffer_pool_num_free %d\n", element->id, fifo->qnn_buf_size, fifo->buffer_pool_num_free);
     pthread_cond_signal (&fifo->not_empty);
 
     pthread_mutex_unlock (&fifo->mutex);
@@ -1281,16 +1174,10 @@ static buf_element_t * qnn_buf_buffer_get (qnn_buf_t * fifo) {
     buf_element_t * buf = nullptr;
 
     pthread_mutex_lock (&fifo->mutex);
-#if 0
-    while (fifo->first == nullptr) {
-        pthread_cond_wait (&fifo->not_empty, &fifo->mutex);
-    }
-#else
     if (fifo->first == nullptr) {
         pthread_mutex_unlock (&fifo->mutex);
         return nullptr;
     }
-#endif
 
     buf = fifo->first;
 
@@ -1337,7 +1224,7 @@ static void qnn_buf_buffer_clear (qnn_buf_t * fifo) {
         buf = next;
     }
 
-    LOGGD("free buffers after clear: %d\n", fifo->buffer_pool_num_free);
+    QNN_LOG_DEBUG("free buffers after clear: %d\n", fifo->buffer_pool_num_free);
     pthread_mutex_unlock (&fifo->mutex);
 }
 
@@ -1376,7 +1263,6 @@ static int qnn_buf_buffer_num_free (qnn_buf_t * self) {
 
 
 static void qnn_buf_buffer_dispose (qnn_buf_t * self) {
-    ENTER_FUNC();
     buf_element_t * buf, * next;
     int received = 0;
 
@@ -1404,8 +1290,6 @@ static void qnn_buf_buffer_dispose (qnn_buf_t * self) {
     pthread_cond_destroy(&self->buffer_pool_cond_not_empty);
     qnn_xfree((void *)self->name);
     qnn_xfree (self);
-
-    LEAVE_FUNC();
 }
 
 
@@ -1417,7 +1301,7 @@ static qnn_buf_t * qnn_buf_new(const char * name, int num_buffers, uint32_t buf_
 
     self = (qnn_buf_t*)qnn_xmalloc(sizeof(qnn_buf_t));
     if (nullptr == self) {
-        LOGGW("malloc memory failed\n");
+        QNN_LOG_WARN("malloc memory failed\n");
         return nullptr;
     }
 
@@ -1439,11 +1323,11 @@ static qnn_buf_t * qnn_buf_new(const char * name, int num_buffers, uint32_t buf_
     if (buf_size % alignment != 0)
         buf_size += alignment - (buf_size % alignment);
 
-    LOGGI("[%s]allocating %d Mbytes memory(alignment = %d)\n", name, (num_buffers * buf_size) / (1 << 20), alignment);
+    QNN_LOG_INFO("[%s]allocating %d Mbytes memory(alignment = %d)\n", name, (num_buffers * buf_size) / (1 << 20), alignment);
 
     multi_buffer = (uint8_t *)qnn_xmalloc_aligned (alignment, num_buffers * buf_size, &self->buffer_pool_base);
     if (nullptr == multi_buffer) {
-        LOGGW("malloc memory failed\n");
+        QNN_LOG_WARN("malloc memory failed\n");
         free(self);
         return nullptr;
     }
@@ -1464,7 +1348,7 @@ static qnn_buf_t * qnn_buf_new(const char * name, int num_buffers, uint32_t buf_
 
         buf = (buf_element_t *)qnn_xmalloc(sizeof (buf_element_t));
         if (nullptr == buf) {
-            LOGGW("malloc memory failed");
+            QNN_LOG_WARN("malloc memory failed");
             free(multi_buffer);
             free(self);
             return nullptr;
@@ -1483,6 +1367,7 @@ static qnn_buf_t * qnn_buf_new(const char * name, int num_buffers, uint32_t buf_
 
     return self;
 }
+#endif
 
 
 static const char * get_qnn_backend_name(int n_backend_type) {
@@ -1492,11 +1377,11 @@ static const char * get_qnn_backend_name(int n_backend_type) {
         case 1:
             return "QNN-GPU";
         case 2:
-            return "QNN-HTP(DSP)";
+            return "QNN-NPU";
         case 3:
             return "ggml";      //the default GGML backend, used to compare performance between QNN backend and the default GGML backend
 
-#if 0 //QNN cDSP and HTA backend would not be used currently, focus on QNN CPU/GPU/HTP(aka DSP) backend currently
+#if 0 //QNN cDSP and HTA backend would not be used currently, focus on QNN CPU/GPU/NPU(aka HTP/DSP) backend currently
         case 3:
             return "QNN-cDSP";
         case 4:
@@ -1529,9 +1414,16 @@ static void ggml_qnn_log_internal(ggml_log_level level, const char * file, const
         int len = vsnprintf(s_ggml_qnn_log_internal_buf + len_prefix, GGML_QNN_LOGBUF_LEN - len_prefix, format, args);
         if (len < (GGML_QNN_LOGBUF_LEN - len_prefix)) {
 #if (defined __ANDROID__) || (defined ANDROID)
-            __android_log_print(level, "KANTV", "%s", s_ggml_qnn_log_internal_buf); //TODO:modify to llama.cpp before submit to upstream
+            //for Android APK
+#if 1// NOT_IN_PR
+            __android_log_print(level, "KANTV", "%s\n", s_ggml_qnn_log_internal_buf);
 #else
-            printf("%s", buffer); //Qualcomm's QNN could running on Window over ARM
+            __android_log_print(level, "ggml-qnn", "%s\n", s_ggml_qnn_log_internal_buf);
+#endif
+            //for Android command line application
+            printf("%s\n", s_ggml_qnn_log_internal_buf);
+#else
+            printf("%s\n", s_ggml_qnn_log_internal_buf);
 #endif
         }
         va_end(args);
@@ -1699,7 +1591,7 @@ public:
 
     const qnn_interface &get_qnn_interface() {
         if (!_qnn_interface.is_loaded()) {
-            LOGGW("pls check why _qnn_interface is not loaded\n");
+            QNN_LOG_WARN("pls check why _qnn_interface is not loaded\n");
         }
         return _qnn_interface;
     }
@@ -1707,14 +1599,14 @@ public:
 
     const QNN_INTERFACE_VER_TYPE &get_qnn_raw_interface() {
         if (!_qnn_interface.is_loaded()) {
-            LOGGW("pls check why _qnn_interface is not loaded\n");
+            QNN_LOG_WARN("pls check why _qnn_interface is not loaded\n");
         }
         return _qnn_raw_interface;
     }
 
     const QNN_SYSTEM_INTERFACE_VER_TYPE &get_qnn_raw_system_interface() {
         if (!_qnn_interface.is_loaded()) {
-            LOGGW("pls check why _qnn_interface is not loaded\n");
+            QNN_LOG_WARN("pls check why _qnn_interface is not loaded\n");
         }
         return _qnn_raw_system_interface;
     }
@@ -1746,7 +1638,7 @@ public:
         QnnDevice_Infrastructure_t device_infra = nullptr;
         int error = _qnn_raw_interface.deviceGetInfrastructure(&device_infra);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to get qnn device infra\n");
+            QNN_LOG_WARN("failed to get qnn device infra\n");
             return 1;
         }
 
@@ -1781,7 +1673,7 @@ public:
 
     int set_high_performance_mode() {
         if (nullptr == _qnn_htp_perfinfra) {
-            LOGGD("perf intra is null\n");
+            QNN_LOG_DEBUG("perf intra is null\n");
             return 1;
         }
 
@@ -1843,7 +1735,6 @@ public:
     }
 
 public:
-    //TODO:refine
     std::map<std::string, std::tuple<Qnn_GraphHandle_t, Qnn_Tensor_t *, Qnn_Tensor_t *, Qnn_Tensor_t *>> _qnn_graph_map;
 
 private:
@@ -1942,14 +1833,14 @@ std::unordered_map<qnn_instance::BackendIdType, const QnnInterface_t *> qnn_inst
 
 void * qnn_instance::alloc_rpcmem(size_t bytes, size_t alignment) {
     if (!_rpcmem_initialized) {
-        LOGGW("rpc memory not initialized\n");
+        QNN_LOG_WARN("rpc memory not initialized\n");
         return nullptr;
     }
 
     auto allocate_bytes = static_cast<int32_t>(bytes + alignment);
     void *buf = _pfn_rpc_mem_alloc(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS, allocate_bytes);
     if (buf == nullptr) {
-        LOGGW("failed to allocate rpc memory\n");
+        QNN_LOG_WARN("failed to allocate rpc memory\n");
         return nullptr;
     }
 
@@ -1957,7 +1848,7 @@ void * qnn_instance::alloc_rpcmem(size_t bytes, size_t alignment) {
                                                          reinterpret_cast<intptr_t>(buf)));
     bool status = _rpcmem_store_map.insert(std::pair<void *, void *>(aligned_buf, buf)).second;
     if (!status) {
-        LOGGW("failed to allocate rpc memory\n");
+        QNN_LOG_WARN("failed to allocate rpc memory\n");
         _pfn_rpc_mem_free(buf);
     }
 
@@ -1967,9 +1858,9 @@ void * qnn_instance::alloc_rpcmem(size_t bytes, size_t alignment) {
 
 void qnn_instance::free_rpcmem(void * buf) {
     if (!_rpcmem_initialized) {
-        LOGGW("rpc memory not initialized\n");
+        QNN_LOG_WARN("rpc memory not initialized\n");
     } else if (0 == _rpcmem_store_map.count(buf)) {
-        LOGGW("no allocated tensor\n");
+        QNN_LOG_WARN("no allocated tensor\n");
     } else {
         _pfn_rpc_mem_free(_rpcmem_store_map[buf]);
         _rpcmem_store_map.erase(buf);
@@ -1980,7 +1871,7 @@ void qnn_instance::free_rpcmem(void * buf) {
 int32_t qnn_instance::rpcmem_to_fd(void *buf) {
     int32_t mem_fd = -1;
     if (!is_rpcmem_initialized()) {
-        LOGGW("rpc memory not initialized\n");
+        QNN_LOG_WARN("rpc memory not initialized\n");
     } else {
         mem_fd = _pfn_rpc_mem_to_fd(buf);
     }
@@ -1991,30 +1882,30 @@ int32_t qnn_instance::rpcmem_to_fd(void *buf) {
 
 int qnn_instance::register_rpcmem(void * p_data, Qnn_Tensor_t * p_tensor) {
     if (nullptr == p_data || (nullptr == p_tensor)) {
-        LOGGW("invalid param\n");
+        QNN_LOG_WARN("invalid param\n");
         return 1;
     }
 
     if (!is_rpcmem_initialized()) {
-        LOGGW("rpc memory not initialized\n");
+        QNN_LOG_WARN("rpc memory not initialized\n");
         return 2;
     }
 
     if (is_rpcmem_allocated(p_data)) {
-        LOGGW("rpc memory already allocated\n");
+        QNN_LOG_WARN("rpc memory already allocated\n");
         //return 3;
     }
     if (is_rpcmem_registered((QNN_VER_PTR(*p_tensor)->memHandle))) {
-        LOGGW("tensor %s has been registered shared memory\n", (QNN_VER_PTR(*p_tensor)->name));
+        QNN_LOG_WARN("tensor %s has been registered shared memory\n", (QNN_VER_PTR(*p_tensor)->name));
         return 4;
     }
 
     int32_t mem_fd = rpcmem_to_fd(p_data);
     if (-1 == mem_fd) {
-        LOGGW("failed to get file descriptor\n");
+        QNN_LOG_WARN("failed to get file descriptor\n");
         return 5;
     }
-    LOGGD("mem_fd %d\n", mem_fd);
+    QNN_LOG_DEBUG("mem_fd %d\n", mem_fd);
     Qnn_MemDescriptor_t descriptor = {
             {QNN_VER_PTR(*p_tensor)->rank, QNN_VER_PTR(*p_tensor)->dimensions, nullptr},
             QNN_VER_PTR(*p_tensor)->dataType,
@@ -2028,11 +1919,11 @@ int qnn_instance::register_rpcmem(void * p_data, Qnn_Tensor_t * p_tensor) {
             /*numDescriptors=*/1,
             &handle);
     if (error != QNN_SUCCESS) {
-        LOGGW("failed to register shared memory, error %d, %s\n", QNN_GET_ERROR_CODE(error),
+        QNN_LOG_WARN("failed to register shared memory, error %d, %s\n", QNN_GET_ERROR_CODE(error),
               strerror(error));
         return 6;
     } else {
-        LOGGI("tensor %s successfully register shared memory\n", (QNN_VER_PTR(*p_tensor)->name));
+        QNN_LOG_INFO("tensor %s successfully register shared memory\n", (QNN_VER_PTR(*p_tensor)->name));
     }
     QNN_VER_PTR(*p_tensor)->memHandle = handle;
     _qnn_mem_set.insert(handle);
@@ -2045,13 +1936,13 @@ void qnn_instance::unregister_rpcmem() {
     Qnn_ErrorHandle_t error = QNN_SUCCESS;
 
     if (_qnn_mem_set.empty()) {
-        LOGGW("no rpcmem registered\n");
+        QNN_LOG_WARN("no rpcmem registered\n");
     }
 
     for (auto &mem_handle : _qnn_mem_set) {
         error = _qnn_interface.qnn_mem_de_register(&mem_handle, 1);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to unregister shared memory, error %d\n", QNN_GET_ERROR_CODE(error));
+            QNN_LOG_WARN("failed to unregister shared memory, error %d\n", QNN_GET_ERROR_CODE(error));
         }
     }
     _qnn_mem_set.clear();
@@ -2065,11 +1956,11 @@ bool qnn_instance::is_rpcmem_allocated(void * buf) {
 
 int qnn_instance::load_backend(std::string & lib_path, const QnnSaver_Config_t ** saver_config) {
     Qnn_ErrorHandle_t error = QNN_SUCCESS;
-    LOGGD("lib_path:%s\n", lib_path.c_str());
+    QNN_LOG_DEBUG("lib_path:%s\n", lib_path.c_str());
 
     void *lib_handle = dlopen(lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (nullptr == lib_handle) {
-        LOGGW("can not open QNN library %s, with error: %s", lib_path.c_str(), dlerror());
+        QNN_LOG_WARN("can not open QNN library %s, with error: %s", lib_path.c_str(), dlerror());
         return 1;
     }
 
@@ -2077,7 +1968,7 @@ int qnn_instance::load_backend(std::string & lib_path, const QnnSaver_Config_t *
     auto get_providers = load_qnn_functionpointers<_pfn_QnnInterface_getProviders *>(lib_handle,
                                                                                      "QnnInterface_getProviders");
     if (nullptr == get_providers) {
-        LOGGW("can not load symbol QnnInterface_getProviders : %s", dlerror());
+        QNN_LOG_WARN("can not load symbol QnnInterface_getProviders : %s", dlerror());
         return 2;
     }
 
@@ -2086,17 +1977,17 @@ int qnn_instance::load_backend(std::string & lib_path, const QnnSaver_Config_t *
     const QnnInterface_t **provider_list = nullptr;
     error = get_providers(&provider_list, &num_providers);
     if (error != QNN_SUCCESS) {
-        LOGGW("failed to get providers, error %d", QNN_GET_ERROR_CODE(error));
+        QNN_LOG_WARN("failed to get providers, error %d", QNN_GET_ERROR_CODE(error));
         return 3;
     }
-    LOGGD("num_providers=%d\n", num_providers);
+    QNN_LOG_DEBUG("num_providers=%d\n", num_providers);
     if (num_providers != _required_num_providers) {
-        LOGGW("providers is %d instead of required %d", num_providers, _required_num_providers);
+        QNN_LOG_WARN("providers is %d instead of required %d", num_providers, _required_num_providers);
         return 4;
     }
 
     if (nullptr == provider_list) {
-        LOGGW("failed to get qnn interface providers\n");
+        QNN_LOG_WARN("failed to get qnn interface providers\n");
         return 5;
     }
     bool found_valid_interface = false;
@@ -2111,56 +2002,55 @@ int qnn_instance::load_backend(std::string & lib_path, const QnnSaver_Config_t *
     }
 
     if (!found_valid_interface) {
-        LOGGW("unable to find a valid qnn interface\n");
+        QNN_LOG_WARN("unable to find a valid qnn interface\n");
         return 6;
     } else {
-        LOGGI("find a valid qnn interface\n");
+        QNN_LOG_INFO("find a valid qnn interface\n");
     }
     set_qnn_raw_interface(qnn_interface);
 
     BackendIdType backend_id = provider_list[0]->backendId;
     _lib_path_to_backend_id[lib_path] = backend_id;
     if (_loaded_backend.count(backend_id) > 0) {
-        LOGGW("lib_path %s is loaded, but backend %d already exists\n",
+        QNN_LOG_WARN("lib_path %s is loaded, but backend %d already exists\n",
               lib_path.c_str(), backend_id);
     }
     _loaded_backend[backend_id] = provider_list[0];
     if (_loaded_lib_handle.count(backend_id) > 0) {
-        LOGGW("closing %p\n", _loaded_lib_handle[backend_id]);
+        QNN_LOG_WARN("closing %p\n", _loaded_lib_handle[backend_id]);
         int dlclose_error = dlclose(_loaded_lib_handle[backend_id]);
         if (dlclose_error != 0) {
-            LOGGW("fail to close %p with error %s\n", _loaded_lib_handle[backend_id], dlerror());
+            QNN_LOG_WARN("fail to close %p with error %s\n", _loaded_lib_handle[backend_id], dlerror());
         }
     }
     _loaded_lib_handle[backend_id] = lib_handle;
     _backend_id = backend_id;
 
-#if 0 //not used since v1.3.8 for purpose of reduce size of APK
+#if 0 //comment it for purpose of reduce size of APK
     QnnSaver_Config_t outputdir_cfg;
     outputdir_cfg.option = QNN_SAVER_CONFIG_OPTION_OUTPUT_DIRECTORY;
-    outputdir_cfg.outputDirectory = "/data/data/com.cdeos.kantv/qnn/";
+    outputdir_cfg.outputDirectory = "/data/local/tmp/";
 
     QnnSaver_Config_t backendid_cfg;
     backendid_cfg.option = QNN_SAVER_CONFIG_OPTION_BACKEND_ID;
     backendid_cfg.backendId = _backend_id;
     const QnnSaver_Config_t *saverCfg[] = {&outputdir_cfg, &backendid_cfg, nullptr};
     if (0 == QnnSaver_initialize(saverCfg)) {
-        LOGGI("QnnSaver_initialize successfully");
+        QNN_LOG_INFO("QnnSaver_initialize successfully");
     } else {
-        LOGGI("QnnSaver_initialize failure");
+        QNN_LOG_WARN("QnnSaver_initialize failure");
     }
 #endif
-
     auto saver_initialize = load_qnn_functionpointers<_pfn_QnnSaver_initialize *>(
             _loaded_lib_handle[backend_id], "QnnSaver_initialize");
     if (nullptr != saver_initialize) {
         error = saver_initialize(saver_config);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to saver_initialize，error %d", QNN_GET_ERROR_CODE(error));
+            QNN_LOG_WARN("failed to saver_initialize，error %d", QNN_GET_ERROR_CODE(error));
             return 7;
         }
     } else {
-        LOGGW("saver_initialize is null\n");
+        QNN_LOG_WARN("saver_initialize is null\n");
     }
 
     return 0;
@@ -2168,20 +2058,17 @@ int qnn_instance::load_backend(std::string & lib_path, const QnnSaver_Config_t *
 
 
 int qnn_instance::unload_backend() {
-    ENTER_FUNC();
     int dlclose_error = 0;
     for (auto &it : _loaded_lib_handle) {
         dlclose_error = dlclose(it.second);
         if (dlclose_error != 0) {
-            LOGGW("failed to close QNN backend %d, error %s\n", it.first, dlerror());
+            QNN_LOG_WARN("failed to close QNN backend %d, error %s\n", it.first, dlerror());
         }
     }
 
     _loaded_lib_handle.clear();
     _lib_path_to_backend_id.clear();
     _loaded_backend.clear();
-
-    LEAVE_FUNC();
 
     return 0;
 }
@@ -2191,18 +2078,18 @@ int qnn_instance::load_system() {
     Qnn_ErrorHandle_t error = QNN_SUCCESS;
 
     std::string system_lib_path = _lib_path + "libQnnSystem.so";
-    LOGGD("system_lib_path:%s\n", system_lib_path.c_str());
+    QNN_LOG_DEBUG("system_lib_path:%s\n", system_lib_path.c_str());
 
     _system_lib_handle = dlopen(system_lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (nullptr == _system_lib_handle) {
-        LOGGW("can not open QNN library %s, error: %s\n", system_lib_path.c_str(), dlerror());
+        QNN_LOG_WARN("can not open QNN library %s, error: %s\n", system_lib_path.c_str(), dlerror());
         return 1;
     }
 
     auto * get_providers = reinterpret_cast<_pfn_QnnSystemInterface_getProviders *>(dlsym(
             _system_lib_handle, "QnnSystemInterface_getProviders"));
     if (nullptr == get_providers) {
-        LOGGW("can not load QNN symbol QnnSystemInterface_getProviders: %s\n", dlerror());
+        QNN_LOG_WARN("can not load QNN symbol QnnSystemInterface_getProviders: %s\n", dlerror());
         return 2;
     }
 
@@ -2210,17 +2097,17 @@ int qnn_instance::load_system() {
     const QnnSystemInterface_t ** provider_list = nullptr;
     error = get_providers(&provider_list, &num_providers);
     if (error != QNN_SUCCESS) {
-        LOGGW("failed to get providers, error %d\n", QNN_GET_ERROR_CODE(error));
+        QNN_LOG_WARN("failed to get providers, error %d\n", QNN_GET_ERROR_CODE(error));
         return 3;
     }
 
     if (num_providers != _required_num_providers) {
-        LOGGW("providers is %d instead of required %d\n", num_providers, _required_num_providers);
+        QNN_LOG_WARN("providers is %d instead of required %d\n", num_providers, _required_num_providers);
         return 4;
     }
 
     if (nullptr == provider_list) {
-        LOGGW("can not get providers\n");
+        QNN_LOG_WARN("can not get providers\n");
         return 5;
     }
 
@@ -2237,10 +2124,10 @@ int qnn_instance::load_system() {
         }
     }
     if (!found_valid_system_interface) {
-        LOGGW("unable to find a valid qnn system interface\n");
+        QNN_LOG_WARN("unable to find a valid qnn system interface\n");
         return 6;
     } else {
-        LOGGI("find a valid qnn system interface\n");
+        QNN_LOG_INFO("find a valid qnn system interface\n");
     }
     set_qnn_raw_system_interface(qnn_system_interface);
 
@@ -2248,9 +2135,9 @@ int qnn_instance::load_system() {
 
     _qnn_interface.qnn_system_context_create(&_qnn_system_handle);
     if (nullptr == _qnn_system_handle) {
-        LOGW("can not create QNN system contenxt\n");
+        QNN_LOG_WARN("can not create QNN system contenxt\n");
     } else {
-        LOGGD("initialize qnn system successfully\n");
+        QNN_LOG_INFO("initialize qnn system successfully\n");
     }
 
     return 0;
@@ -2258,33 +2145,30 @@ int qnn_instance::load_system() {
 
 
 int qnn_instance::unload_system() {
-    ENTER_FUNC();
-
     int result = 0;
 
     if (nullptr == _system_lib_handle) {
-        LOGGD("system lib handle is null\n");
+        QNN_LOG_DEBUG("system lib handle is null\n");
         return 1;
     }
 
     if (nullptr != _qnn_system_handle) {
         result = _qnn_interface.qnn_system_context_free(_qnn_system_handle);
         if (result != QNN_SUCCESS) {
-            LOGGW("failed to free QNN system context\n");
+            QNN_LOG_WARN("failed to free QNN system context\n");
         }
         _qnn_system_handle = nullptr;
     }
 
     int dlclose_error = dlclose(_system_lib_handle);
     if (dlclose_error != 0) {
-        LOGGW("failed to close QnnSystem library, error %s\n", dlerror());
+        QNN_LOG_WARN("failed to close QnnSystem library, error %s\n", dlerror());
         return 2;
     }
 
     _system_lib_handle = nullptr;
-    LEAVE_FUNC();
 
-    return 0;
+    return result;
 }
 
 
@@ -2326,29 +2210,29 @@ static void ggml_qnn_logcallback(const char * fmt,
         int len_content = 0;
         memset(s_ggml_qnn_logbuf, 0, GGML_QNN_LOGBUF_LEN);
         len_content = vsnprintf(reinterpret_cast<char *const>(s_ggml_qnn_logbuf), GGML_QNN_LOGBUF_LEN, fmt, argp);
-        //LOGGD("%8.1fms [%-7s] %s ", ms, levelStr, s_ggml_qnn_logbuf);
+        QNN_LOG_DEBUG("%8.1fms [%-7s] %s ", ms, levelStr, s_ggml_qnn_logbuf);
     }
 }
 
 
 int qnn_instance::qnn_init(const QnnSaver_Config_t ** saver_config) {
     BackendIdType backend_id = QNN_BACKEND_ID_NULL;
-    LOGGD("enter qni_init\n");
+    QNN_LOG_DEBUG("enter qni_init\n");
 
     const std::lock_guard<std::mutex> lock(_init_mutex);
 
     if (0 != load_system()) {
-        LOGGW("can not load QNN system lib, pls check why?\n");
+        QNN_LOG_WARN("can not load QNN system lib, pls check why?\n");
         return 1;
     } else {
-        LOGGD("load QNN system lib successfully\n");
+        QNN_LOG_DEBUG("load QNN system lib successfully\n");
     }
 
     std::string bakend_lib_path = _lib_path + _backend_name;
     if (0 == _lib_path_to_backend_id.count(bakend_lib_path)) {
         int is_load_ok = load_backend(bakend_lib_path, saver_config);
         if (0 != is_load_ok) {
-            LOGGW("failed to load QNN backend\n");
+            QNN_LOG_WARN("failed to load QNN backend\n");
             return 2;
         }
     }
@@ -2356,7 +2240,7 @@ int qnn_instance::qnn_init(const QnnSaver_Config_t ** saver_config) {
     backend_id = _lib_path_to_backend_id[bakend_lib_path];
     if (0 == _loaded_backend.count(backend_id) ||
         0 == _loaded_lib_handle.count(backend_id)) {
-        LOGGW("library %s is loaded but loaded backend count=%zu, loaded lib_handle count=%zu\n",
+        QNN_LOG_WARN("library %s is loaded but loaded backend count=%zu, loaded lib_handle count=%zu\n",
               bakend_lib_path.c_str(),
               _loaded_backend.count(backend_id),
               _loaded_lib_handle.count(backend_id));
@@ -2371,80 +2255,69 @@ int qnn_instance::qnn_init(const QnnSaver_Config_t ** saver_config) {
     _qnn_raw_interface.logCreate(ggml_qnn_logcallback, _qnn_log_level, &_qnn_log_handle);
 #endif
     if (nullptr == _qnn_log_handle) {
-        LOGGW("why failed to initialize qnn log\n"); //DSP backend not work on Qualcomm SoC based low-end phone
+        QNN_LOG_WARN("why failed to initialize qnn log\n"); //DSP backend not work on Qualcomm SoC based low-end phone
         return 4;
     } else {
-        LOGGD("initialize qnn log successfully\n");
+        QNN_LOG_DEBUG("initialize qnn log successfully\n");
     }
-
 
     std::vector<const QnnBackend_Config_t *> temp_backend_config;
     _qnn_interface.qnn_backend_create(_qnn_log_handle, temp_backend_config.empty() ? nullptr
                                                                                    : temp_backend_config.data(),
                                       &_qnn_backend_handle);
     if (nullptr == _qnn_backend_handle) {
-        LOGGW("why failed to initialize qnn backend\n");
+        QNN_LOG_WARN("why failed to initialize qnn backend\n");
         return 5;
     } else {
-        LOGGD("initialize qnn backend successfully\n");
+        QNN_LOG_DEBUG("initialize qnn backend successfully\n");
     }
 
     if (nullptr != _qnn_raw_interface.propertyHasCapability) {
         auto qnnStatus = _qnn_raw_interface.propertyHasCapability(QNN_PROPERTY_GROUP_DEVICE);
         if (QNN_PROPERTY_NOT_SUPPORTED == qnnStatus) {
-            LOGGW("device property is not supported\n");
+            QNN_LOG_WARN("device property is not supported\n");
         }
         if (QNN_PROPERTY_ERROR_UNKNOWN_KEY == qnnStatus) {
-            LOGGW("device property is not known to backend\n");
+            QNN_LOG_WARN("device property is not known to backend\n");
         }
     }
 
     auto qnnStatus = _qnn_raw_interface.deviceCreate(_qnn_log_handle, nullptr, &_qnn_device_handle);
     if (QNN_SUCCESS != qnnStatus && QNN_DEVICE_ERROR_UNSUPPORTED_FEATURE != qnnStatus) {
-        LOGGW("failed to create QNN device\n");
+        QNN_LOG_WARN("failed to create QNN device\n");
     } else {
-        LOGGI("create device successfully\n");
+        QNN_LOG_INFO("create device successfully\n");
     }
-
-    /*
-    std::vector<const QnnDevice_Config_t*> temp_device_config;
-    _qnn_interface.qnn_device_create(_qnn_log_handle, temp_device_config.empty() ? nullptr : temp_device_config.data(), &_qnn_device_handle);
-    if (nullptr == _qnn_device_handle) {
-        LOGGW("why failed to initialize qnn device\n");
-        //return 6;
-    }
-    */
 
     if (ggml_qnn_profile_level::profile_off != _profile_level) {
-        LOGGI("profiling turned on; level = %d", _profile_level);
+        QNN_LOG_INFO("profiling turned on; level = %d", _profile_level);
         if (ggml_qnn_profile_level::profile_basic == _profile_level) {
-            LOGGI("basic profiling requested. creating Qnn Profile object\n");
+            QNN_LOG_INFO("basic profiling requested. creating Qnn Profile object\n");
             if (QNN_PROFILE_NO_ERROR != _qnn_raw_interface.profileCreate(
                     _qnn_backend_handle, QNN_PROFILE_LEVEL_BASIC, &_qnn_profile_handle)) {
-                LOGGW("unable to create profile handle in the backend\n");
+                QNN_LOG_WARN("unable to create profile handle in the backend\n");
                 return 7;
             } else {
-                LOGGD("initialize qnn profile successfully\n");
+                QNN_LOG_DEBUG("initialize qnn profile successfully\n");
             }
         } else if (ggml_qnn_profile_level::profile_detail == _profile_level) {
-            LOGGI("detailed profiling requested. Creating Qnn Profile object\n");
+            QNN_LOG_INFO("detailed profiling requested. Creating Qnn Profile object\n");
             if (QNN_PROFILE_NO_ERROR != _qnn_raw_interface.profileCreate(
                     _qnn_backend_handle, QNN_PROFILE_LEVEL_DETAILED, &_qnn_profile_handle)) {
-                LOGGW("unable to create profile handle in the backend\n");
+                QNN_LOG_WARN("unable to create profile handle in the backend\n");
                 return 7;
             } else {
-                LOGGD("initialize qnn profile successfully\n");
+                QNN_LOG_DEBUG("initialize qnn profile successfully\n");
             }
         }
     }
 
-
     _rpc_lib_handle = dlopen("libcdsprpc.so", RTLD_NOW | RTLD_LOCAL);
     if (nullptr == _rpc_lib_handle) {
-        LOGGW("failed to load qualcomm's rpc lib, error:%s\n", dlerror());
+        QNN_LOG_WARN("failed to load qualcomm's rpc lib, error:%s\n", dlerror());
         return 9;
     } else {
-        LOGGD("load rpcmem lib successfully\n");
+        QNN_LOG_DEBUG("load rpcmem lib successfully\n");
         set_rpcmem_initialized(true);
     }
     _pfn_rpc_mem_init   = reinterpret_cast<pfn_rpc_mem_init>(dlsym(_rpc_lib_handle, "rpcmem_init"));
@@ -2454,7 +2327,7 @@ int qnn_instance::qnn_init(const QnnSaver_Config_t ** saver_config) {
     _pfn_rpc_mem_to_fd  = reinterpret_cast<pfn_rpc_mem_to_fd>(dlsym(_rpc_lib_handle,"rpcmem_to_fd"));
     if (nullptr == _pfn_rpc_mem_alloc || nullptr == _pfn_rpc_mem_free
         || nullptr == _pfn_rpc_mem_to_fd) {
-        LOGGW("unable to access symbols in QNN RPC lib. dlerror(): %s", dlerror());
+        QNN_LOG_WARN("unable to access symbols in QNN RPC lib. dlerror(): %s", dlerror());
         dlclose(_rpc_lib_handle);
         return 10;
     }
@@ -2468,37 +2341,35 @@ int qnn_instance::qnn_init(const QnnSaver_Config_t ** saver_config) {
                                                                   : temp_context_config.data(),
                                       &_qnn_context_handle);
     if (nullptr == _qnn_context_handle) {
-        LOGGW("why failed to initialize qnn context\n");
+        QNN_LOG_WARN("why failed to initialize qnn context\n");
         return 8;
     } else {
-        LOGGD("initialize qnn context successfully\n");
+        QNN_LOG_DEBUG("initialize qnn context successfully\n");
     }
 
-    LOGGD("leave qni_init\n");
+    QNN_LOG_DEBUG("leave qni_init\n");
 
     return 0;
 }
 
 
-//QNN SDK would/might/should release all allocated resource in SDK's internal
 int qnn_instance::qnn_finalize() {
     int ret_status = 0;
     Qnn_ErrorHandle_t error = QNN_SUCCESS;
-    ENTER_FUNC();
 
     if (nullptr != _pfn_rpc_mem_deinit) // make Qualcomm's SoC based low-end phone happy
         _pfn_rpc_mem_deinit();
 
     if (dlclose(_rpc_lib_handle) != 0) {
-        LOGGW("failed to unload qualcomm's rpc lib, error:%s\n", dlerror());
+        QNN_LOG_WARN("failed to unload qualcomm's rpc lib, error:%s\n", dlerror());
     } else {
-        LOGGD("succeed to close rpcmem lib\n");
+        QNN_LOG_DEBUG("succeed to close rpcmem lib\n");
     }
 
     if (nullptr != _qnn_context_handle) {
         error = _qnn_interface.qnn_context_free(_qnn_context_handle, _qnn_profile_handle);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to free QNN context_handle: ID %u, error %d\n",
+            QNN_LOG_WARN("failed to free QNN context_handle: ID %u, error %d\n",
                   _qnn_interface.get_backend_id(), QNN_GET_ERROR_CODE(error));
 
         }
@@ -2508,7 +2379,7 @@ int qnn_instance::qnn_finalize() {
     if (nullptr != _qnn_profile_handle) {
         error = _qnn_interface.qnn_profile_free(_qnn_profile_handle);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to free QNN profile_handle: ID %u, error %d\n",
+            QNN_LOG_WARN("failed to free QNN profile_handle: ID %u, error %d\n",
                   _qnn_interface.get_backend_id(), QNN_GET_ERROR_CODE(error));
 
         }
@@ -2518,7 +2389,7 @@ int qnn_instance::qnn_finalize() {
     if (nullptr != _qnn_device_handle) {
         error = _qnn_interface.qnn_device_free(_qnn_device_handle);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to free QNN device_handle: ID %u, error %d\n",
+            QNN_LOG_WARN("failed to free QNN device_handle: ID %u, error %d\n",
                   _qnn_interface.get_backend_id(), QNN_GET_ERROR_CODE(error));
 
         }
@@ -2528,7 +2399,7 @@ int qnn_instance::qnn_finalize() {
     if (nullptr != _qnn_backend_handle) {
         error = _qnn_interface.qnn_backend_free(_qnn_backend_handle);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to free QNN backend_handle: ID %u, error %d\n",
+            QNN_LOG_WARN("failed to free QNN backend_handle: ID %u, error %d\n",
                   _qnn_interface.get_backend_id(), QNN_GET_ERROR_CODE(error));
         }
         _qnn_backend_handle = nullptr;
@@ -2538,7 +2409,7 @@ int qnn_instance::qnn_finalize() {
     if (nullptr != _qnn_log_handle) {
         error = _qnn_interface.qnn_log_free(_qnn_log_handle);
         if (error != QNN_SUCCESS) {
-            LOGGW("failed to free QNN log_handle: ID %u, error %d\n",
+            QNN_LOG_WARN("failed to free QNN log_handle: ID %u, error %d\n",
                   _qnn_interface.get_backend_id(), QNN_GET_ERROR_CODE(error));
         }
         _qnn_log_handle = nullptr;
@@ -2548,8 +2419,6 @@ int qnn_instance::qnn_finalize() {
 
     unload_system();
 
-    LEAVE_FUNC();
-
     return ret_status;
 }
 
@@ -2558,20 +2427,18 @@ int qnn_instance::init_qnn_graph(const char * graph_name, bool debug, uint8_t do
                                    const QnnGraph_Config_t ** graph_configs) {
     int result = 0;
 
-    ENTER_FUNC();
-
     if (nullptr == graph_name) {
-        LOGGW("graph name is null\n");
+        QNN_LOG_WARN("graph name is null\n");
         return 1;
     }
 
     if (!_graph_name.empty()) {
-        LOGGW("qnn model for graph %s already initialized\n", graph_name);
+        QNN_LOG_WARN("qnn model for graph %s already initialized\n", graph_name);
         return 2;
     }
 
     if (!do_node_validation) {
-        LOGGW("node validation disabled, backend will not perform op validation prior to adding node\n");
+        QNN_LOG_WARN("node validation disabled, backend will not perform op validation prior to adding node\n");
     }
 
     _graph_name = graph_name;
@@ -2581,30 +2448,26 @@ int qnn_instance::init_qnn_graph(const char * graph_name, bool debug, uint8_t do
     result = _qnn_raw_interface.graphCreate(_qnn_context_handle, graph_name, graph_configs,
                                             &_qnn_graph_handle);
     if (result != QNN_GRAPH_NO_ERROR || nullptr == _qnn_graph_handle) {
-        LOGGW("failed to create graph in qnn context\n");
+        QNN_LOG_WARN("failed to create graph in qnn context\n");
         return 3;
     } else {
-        LOGGI("succeed to create graph %s, %p\n", graph_name, _qnn_graph_handle);
+        QNN_LOG_INFO("succeed to create graph %s, %p\n", graph_name, _qnn_graph_handle);
     }
 
-    LEAVE_FUNC();
     return 0;
 }
 
 
 int qnn_instance::finalize_qnn_graph() {
-    ENTER_FUNC();
     if (nullptr != _qnn_graph_handle) {
         if (_qnn_raw_interface.graphFinalize(_qnn_graph_handle, _qnn_profile_handle, nullptr) !=
             QNN_GRAPH_NO_ERROR) {
-            LOGGW("finalizing graph failure\n");
+            QNN_LOG_WARN("finalizing graph failure\n");
             //return 1;
         }
     } else {
-        LOGGD("qnn graph handle is null\n");
+        QNN_LOG_DEBUG("qnn graph handle is null\n");
     }
-
-    LEAVE_FUNC();
 
     return 0;
 }
@@ -2616,63 +2479,86 @@ int qnn_instance::finalize_qnn_graph() {
 //  implementation of GGML's QNN backend
 //
 // =================================================================================================
-//TODO: refine / improvement
-static bool ggml_qnn_can_handle_op(const struct ggml_tensor * src0, const struct ggml_tensor * src1,
-                                 struct ggml_tensor * dst) {
-    const int64_t ne00 = src0->ne[0];
-    const int64_t ne01 = src0->ne[1];
-    const int64_t ne10 = src1->ne[0];
-    const int64_t ne11 = src1->ne[1];
+static bool ggml_qnn_can_handle_op(const struct ggml_tensor * tensor, bool b_dump_tensor_info) {
+    if (nullptr == tensor)
+        return false;
 
-    const int64_t ne0 = dst->ne[0];
-    const int64_t ne1 = dst->ne[1];
-
-    //double check
-    bool supported_op = ((dst->op == GGML_OP_ADD) || (dst->op == GGML_OP_MUL) || (dst->op == GGML_OP_MUL_MAT));
-    if (!supported_op) {
-        LOGGD("op %d(%s)not support", dst->op, ggml_op_name(dst->op));
+    if (ggml_is_empty(tensor) || tensor->op == GGML_OP_RESHAPE || tensor->op == GGML_OP_TRANSPOSE || tensor->op == GGML_OP_VIEW || tensor->op == GGML_OP_PERMUTE || tensor->op == GGML_OP_NONE) {
         return false;
     }
 
+    if (b_dump_tensor_info) {
+        QNN_LOG_DEBUG("op name:%s, tensor type:%s", ggml_op_name(tensor->op),
+                      ggml_type_name(tensor->type));
+        if (nullptr != tensor->src[0]) {
+            QNN_LOG_DEBUG("src0 type:%s", ggml_type_name(tensor->src[0]->type));
+        }
+        if (nullptr != tensor->src[1]) {
+            QNN_LOG_DEBUG("src1 type:%s", ggml_type_name(tensor->src[1]->type));
+        }
+    }
 
-    //make QNN SDK happy
-    if (dst->op == GGML_OP_ADD) {
-        return (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16) &&
-               (src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16) &&
-               (dst->type == GGML_TYPE_F32 || dst->type == GGML_TYPE_F16) && ((ne00 > 1 && ne01 > 1 && ne10 > 1 && ne11 > 1)) &&
-               (src0->rank == src1->rank);
+    //ensure tensor->src[0] and tensor->src[1] is not nullptr
+    bool supported_op = ((tensor->op == GGML_OP_ADD) || (tensor->op == GGML_OP_MUL) || (tensor->op == GGML_OP_MUL_MAT));
+    if (!supported_op) {
+        return false;
+    }
+
+    const struct ggml_tensor * src0 = tensor->src[0];
+    const struct ggml_tensor * src1 = tensor->src[1];
+
+    const int64_t ne00 = tensor->src[0]->ne[0];
+    const int64_t ne01 = tensor->src[0]->ne[1];
+
+    const int64_t ne10 = tensor->src[1]->ne[0];
+    const int64_t ne11 = tensor->src[1]->ne[1];
+
+    const int64_t ne0 = tensor->ne[0];
+    const int64_t ne1 = tensor->ne[1];
+
+    //make ggml_get_tensor_rank and QNN SDK happy
+    if ((ne00 <= 1 || ne01 <= 1 || ne10 <= 1 || ne11 <= 1)) {
+        return false;
+    }
+
+    if (tensor->op == GGML_OP_ADD) {
+        //TODO: this is limitation
+        return (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16)
+               && (src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16)
+               && (tensor->type == GGML_TYPE_F32 || tensor->type == GGML_TYPE_F16);
 
     }
 
-    if (dst->op == GGML_OP_MUL_MAT) {
-#if 1 // log output have significant effect to performance but useful during development stage
-        LOGGD("GGML_OP_MUL_MAT");
-        LOGGI("%15s: rank = %d, type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-              src0->name, src0->rank,
-              src0->type, ggml_type_name(src0->type), src0->ne[0], src0->ne[1], src0->ne[2],
-              src0->nb[0], src0->nb[1], src0->nb[2]);
-        LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-              src1->name, src1->rank,
-              src1->type, ggml_type_name(src1->type), src1->ne[0], src1->ne[1], src1->ne[2],
-              src1->nb[0], src1->nb[1], src1->nb[2]);
-        LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-              dst->name, dst->rank,
-              dst->type, ggml_type_name(dst->type), dst->ne[0], dst->ne[1], dst->ne[2], dst->nb[0],
-              dst->nb[1], dst->nb[2]);
-#endif
+    if (tensor->op == GGML_OP_MUL_MAT) {
+        if (b_dump_tensor_info) {
+            QNN_LOG_DEBUG("GGML_OP_MUL_MAT");
+            QNN_LOG_DEBUG(
+                    "%15s: type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+                    src0->name,
+                    src0->type, ggml_type_name(src0->type), src0->ne[0], src0->ne[1], src0->ne[2],
+                    src0->nb[0], src0->nb[1], src0->nb[2]);
+            QNN_LOG_DEBUG(
+                    "%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+                    src1->name,
+                    src1->type, ggml_type_name(src1->type), src1->ne[0], src1->ne[1], src1->ne[2],
+                    src1->nb[0], src1->nb[1], src1->nb[2]);
+            QNN_LOG_DEBUG(
+                    "%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+                    tensor->name,
+                    tensor->type, ggml_type_name(tensor->type), tensor->ne[0], tensor->ne[1], tensor->ne[2],
+                    tensor->nb[0],
+                    tensor->nb[1], tensor->nb[2]);
+        }
+
     }
 
-    //make QNN SDK happy
-    return  (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16) &&
-            (src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16) &&
-            (src0->type == src1->type) && (src0->type == dst->type) && ((ne00 > 1 && ne01 > 1 && ne10 > 1 && ne11 > 1));
-
-
+    //TODO: this is limitation
+    return  (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16)
+            && (src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16)
+            && (src0->type == src1->type) && (src0->type == tensor->type);
 }
 
 
-//ref: PoC-S26: offload simple f32 2x2 matrix addition operation to QNN CPU
-// https://github.com/zhouwg/kantv/blob/kantv-poc-with-qnn/core/ggml/jni/ggml-jni-impl-external.cpp#L6736
 static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     Qnn_ErrorHandle_t error                     = QNN_SUCCESS;
     bool graph_initialized                      = false;
@@ -2690,7 +2576,7 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
     Qnn_Tensor_t * tensor_2                     = nullptr;
 
     Qnn_QuantizeParams_t quantize_param         = QNN_QUANTIZE_PARAMS_INIT;
-    Qnn_OpConfig_t qnn_opconfig                 = QNN_OPCONFIG_INIT;
+    Qnn_OpConfig_t qnn_op_config                 = QNN_OPCONFIG_INIT;
     Qnn_Param_t qnn_params[]                    = {};
 
     enum ggml_op ggmlop                         = GGML_OP_ADD;
@@ -2698,49 +2584,48 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
     Qnn_DataType_t src1_qnn_type                = QNN_DATATYPE_FLOAT_32;
     Qnn_DataType_t dst_qnn_type                 = QNN_DATATYPE_FLOAT_32;
 
-
     if ((nullptr == src0) || (nullptr == src1) || (nullptr == dst)) {
-        LOGGW("pls check why GGML tensor is null");
+        QNN_LOG_WARN("pls check why GGML tensor is null");
         return;
     }
     tensor_0                                    = (Qnn_Tensor_t *)src0->extra;
     tensor_1                                    = (Qnn_Tensor_t *)src1->extra;
     tensor_2                                    = (Qnn_Tensor_t *)dst->extra;
     if ((nullptr == tensor_0) || (nullptr == tensor_1) || (nullptr == tensor_2)) {
-        LOGGW("pls check why QNN tensor is null");
+        QNN_LOG_WARN("pls check why QNN tensor is null");
         return;
     }
     ctx                                         = (struct ggml_backend_qnn_context *)g_qnn_backend->context;
     if (nullptr == ctx) {
-        LOGGW("pls check why backend ctx is null");
+        QNN_LOG_WARN("pls check why backend ctx is null");
         return;
     }
     instance                                    = ctx->instance;
     if (nullptr == instance) {
-        LOGGW("pls check why qnn instance is null");
+        QNN_LOG_WARN("pls check why qnn instance is null");
         return;
     }
     QNN_INTERFACE_VER_TYPE qnn_raw_interface    = ctx->raw_interface;
 
     n_begin_time                                = ggml_time_us();
-#if 0  //it works fine with whisper.cpp and llama.cpp. comment them because focus on mulmat in llama.cpp inference since 04-23-2024
-    LOGGD("call %s\n", __func__);
-    LOGGI("%15s: rank = %d, type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src0->name, src0->rank,
+#if 1
+    QNN_LOG_DEBUG("call %s\n", __func__);
+    QNN_LOG_DEBUG("%15s: type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src0->name,
           src0->type, ggml_type_name(src0->type), src0->ne[0], src0->ne[1], src0->ne[2],
           src0->nb[0], src0->nb[1], src0->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src1->name, src1->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src1->name,
           src1->type, ggml_type_name(src1->type), src1->ne[0], src1->ne[1], src1->ne[2],
           src1->nb[0], src1->nb[1], src1->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          dst->name, dst->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          dst->name,
           dst->type, ggml_type_name(dst->type), dst->ne[0], dst->ne[1], dst->ne[2], dst->nb[0],
           dst->nb[1], dst->nb[2]);
-    LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
-    LOGGD("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
-    LOGGD("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
-    LOGGD("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
+    QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+    QNN_LOG_DEBUG("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
+    QNN_LOG_DEBUG("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
+    QNN_LOG_DEBUG("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
 #endif
 
     QNN_VER_PTR(*tensor_0)->type = QNN_TENSOR_TYPE_APP_WRITE;
@@ -2753,7 +2638,6 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                                      (uint32_t) src1->ne[2], (uint32_t) src1->ne[3]};
     uint32_t dimensions_output[]    = {(uint32_t) dst->ne[0], (uint32_t) dst->ne[1],
                                      (uint32_t) dst->ne[2], (uint32_t) dst->ne[3]};
-
 
     src0_qnn_type                   = qnn_datatype_from_ggml_datatype(src0->type);
     src1_qnn_type                   = qnn_datatype_from_ggml_datatype(src1->type);
@@ -2768,27 +2652,27 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
 
     if (!graph_initialized) {
         graph_name = graph_name + "_" + std::to_string(ctx->threads) + src0->name + "_" + src1->name;
-        LOGGD("graph name %s", graph_name.c_str());
+        QNN_LOG_DEBUG("graph name %s", graph_name.c_str());
         //QnnGraph_Config_t graph_config;
         //graph_config.option       = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
         //graph_config.customConfig = strdup(graph_name.c_str());
         //const QnnGraph_Config_t  * p_graph_config = &graph_config;
         error = qnn_raw_interface.graphCreate(instance->get_qnn_context_handle(), graph_name.c_str(), nullptr, &graph_handle);
         if (QNN_SUCCESS != error) {
-            LOGGI("can't create qnn graph handle with graph name %s, error = %d\n", graph_name.c_str(), error);
+            QNN_LOG_INFO("can't create qnn graph handle with graph name %s, error = %d\n", graph_name.c_str(), error);
             return;
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_0);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_1);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_2);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
 
         QNN_VER_PTR(*tensor_0)->clientBuf = {src0->data, ggml_get_tensor_data_size(src0)};
@@ -2802,7 +2686,7 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
         Qnn_Tensor_t tensor_outputs[] = {
                 *tensor_2
         };
-        Qnn_OpConfig_t opconfig = {
+        Qnn_OpConfig_t op_config = {
                 (Qnn_OpConfigVersion_t) 1, .v1 = {
                         "ggml_op_add",
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
@@ -2815,17 +2699,17 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
                         tensor_outputs
                 }
         };
-        error = qnn_raw_interface.graphAddNode(graph_handle, opconfig);
+        error = qnn_raw_interface.graphAddNode(graph_handle, op_config);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphFinalize(graph_handle, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         auto  graph_item = std::make_tuple(graph_handle, tensor_0, tensor_1, tensor_2);
         instance->_qnn_graph_map[map_entry] = graph_item;
@@ -2836,8 +2720,7 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
         tensor_1     = std::get<2>(graph_item);
         tensor_2     = std::get<3>(graph_item);
 
-        //comment them because focus on mulmat in llama.cpp inference since 04-23-2024
-        //LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+        //QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
         uint32_t dimensions_input_0[] = {(uint32_t) src0->ne[0], (uint32_t) src0->ne[1],
                                          (uint32_t) src0->ne[2], (uint32_t) src0->ne[3]};
         uint32_t dimensions_input_1[] = {(uint32_t) src1->ne[0], (uint32_t) src1->ne[1],
@@ -2867,14 +2750,13 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
         };
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
     }
     n_end_time = ggml_time_us();
     n_durtion = (n_end_time - n_begin_time) / 1000;
-    //comment them because focus on mulmat in llama.cpp inference since 04-23-2024
-    //LOGGD("duration of ggml_qnn_add : %lld milliseconds\n", n_durtion);
-    //LOGGD("call %s done\n", __func__);
+    //QNN_LOG_DEBUG("duration of ggml_qnn_add : %lld milliseconds\n", n_durtion);
+    //QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
@@ -2888,7 +2770,6 @@ static void ggml_qnn_add(const ggml_tensor * src0, const ggml_tensor * src1, ggm
  * mul_mat_f16_f32: src0 is F16 and src1 is F32.
  * mul_mat_q_f32: src0 is quantized (Q4_0, Q4_1, ...), and src1 is F32.
 */
-
 static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     Qnn_ErrorHandle_t error                     = QNN_SUCCESS;
     bool graph_initialized                      = false;
@@ -2906,7 +2787,7 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
     Qnn_Tensor_t * tensor_2                     = nullptr;
 
     Qnn_QuantizeParams_t quantize_param         = QNN_QUANTIZE_PARAMS_INIT;
-    Qnn_OpConfig_t qnn_opconfig                 = QNN_OPCONFIG_INIT;
+    Qnn_OpConfig_t qnn_op_config                 = QNN_OPCONFIG_INIT;
     Qnn_Param_t qnn_params[]                    = {};
 
     enum ggml_op ggmlop                         = GGML_OP_ADD;
@@ -2914,48 +2795,49 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
     Qnn_DataType_t src1_qnn_type                = QNN_DATATYPE_FLOAT_32;
     Qnn_DataType_t dst_qnn_type                 = QNN_DATATYPE_FLOAT_32;
 
-
     if ((nullptr == src0) || (nullptr == src1) || (nullptr == dst)) {
-        LOGGW("pls check why GGML tensor is null");
+        QNN_LOG_WARN("pls check why GGML tensor is null");
         return;
     }
     tensor_0                                    = (Qnn_Tensor_t *)src0->extra;
     tensor_1                                    = (Qnn_Tensor_t *)src1->extra;
     tensor_2                                    = (Qnn_Tensor_t *)dst->extra;
     if ((nullptr == tensor_0) || (nullptr == tensor_1) || (nullptr == tensor_2)) {
-        LOGGW("pls check why QNN tensor is null");
+        QNN_LOG_WARN("pls check why QNN tensor is null");
         return;
     }
     ctx                                         = (struct ggml_backend_qnn_context *)g_qnn_backend->context;
     if (nullptr == ctx) {
-        LOGGW("pls check why backend ctx is null");
+        QNN_LOG_WARN("pls check why backend ctx is null");
         return;
     }
     instance                                    = ctx->instance;
     if (nullptr == instance) {
-        LOGGW("pls check why qnn instance is null");
+        QNN_LOG_WARN("pls check why qnn instance is null");
         return;
     }
     QNN_INTERFACE_VER_TYPE qnn_raw_interface    = ctx->raw_interface;
 
     n_begin_time                                = ggml_time_us();
-    LOGGD("call %s\n", __func__);
-    LOGGI("%15s: rank = %d, type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src0->name, src0->rank,
+#if 1
+    QNN_LOG_DEBUG("call %s\n", __func__);
+    QNN_LOG_DEBUG("%15s: type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src0->name,
           src0->type, ggml_type_name(src0->type), src0->ne[0], src0->ne[1], src0->ne[2],
           src0->nb[0], src0->nb[1], src0->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src1->name, src1->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src1->name,
           src1->type, ggml_type_name(src1->type), src1->ne[0], src1->ne[1], src1->ne[2],
           src1->nb[0], src1->nb[1], src1->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          dst->name, dst->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          dst->name,
           dst->type, ggml_type_name(dst->type), dst->ne[0], dst->ne[1], dst->ne[2], dst->nb[0],
           dst->nb[1], dst->nb[2]);
-    LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
-    LOGGD("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
-    LOGGD("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
-    LOGGD("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
+    QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+    QNN_LOG_DEBUG("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
+    QNN_LOG_DEBUG("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
+    QNN_LOG_DEBUG("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
+#endif
 
     QNN_VER_PTR(*tensor_0)->type = QNN_TENSOR_TYPE_APP_WRITE;
     QNN_VER_PTR(*tensor_1)->type = QNN_TENSOR_TYPE_APP_WRITE;
@@ -2981,23 +2863,23 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
 
     if (!graph_initialized) {
         graph_name = graph_name + "_" + std::to_string(ctx->threads) + src0->name + "_" + src1->name;
-        LOGGD("graph name %s", graph_name.c_str());
+        QNN_LOG_DEBUG("graph name %s", graph_name.c_str());
         error = qnn_raw_interface.graphCreate(instance->get_qnn_context_handle(), graph_name.c_str(), nullptr, &graph_handle);
         if (QNN_SUCCESS != error) {
-            LOGGI("can't create qnn graph handle with graph name %s, error = %d\n", graph_name.c_str(), error);
+            QNN_LOG_INFO("can't create qnn graph handle with graph name %s, error = %d\n", graph_name.c_str(), error);
             return;
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_0);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_1);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_2);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
 
         QNN_VER_PTR(*tensor_0)->clientBuf = {src0->data, ggml_get_tensor_data_size(src0)};
@@ -3011,7 +2893,7 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
         Qnn_Tensor_t tensor_outputs[] = {
                 *tensor_2
         };
-        Qnn_OpConfig_t opconfig = {
+        Qnn_OpConfig_t op_config = {
                 (Qnn_OpConfigVersion_t) 1, .v1 = {
                         "ggml_op_mul_mat",
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
@@ -3024,17 +2906,17 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
                         tensor_outputs
                 }
         };
-        error = qnn_raw_interface.graphAddNode(graph_handle, opconfig);
+        error = qnn_raw_interface.graphAddNode(graph_handle, op_config);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphFinalize(graph_handle, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         auto  graph_item = std::make_tuple(graph_handle, tensor_0, tensor_1, tensor_2);
         instance->_qnn_graph_map[map_entry] = graph_item;
@@ -3045,7 +2927,7 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
         tensor_1     = std::get<2>(graph_item);
         tensor_2     = std::get<3>(graph_item);
 
-        LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+        QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
         uint32_t dimensions_input_0[] = {(uint32_t) src0->ne[0], (uint32_t) src0->ne[1],
                                          (uint32_t) src0->ne[2], (uint32_t) src0->ne[3]};
         uint32_t dimensions_input_1[] = {(uint32_t) src1->ne[0], (uint32_t) src1->ne[1],
@@ -3075,13 +2957,13 @@ static void ggml_qnn_mul_mat(const ggml_tensor * src0, const ggml_tensor * src1,
         };
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
     }
     n_end_time = ggml_time_us();
     n_durtion = (n_end_time - n_begin_time) / 1000;
-    LOGGD("duration of ggml_qnn_mul_mat : %lld milliseconds\n", n_durtion);
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("duration of ggml_qnn_mul_mat : %lld milliseconds\n", n_durtion);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
@@ -3097,7 +2979,7 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
     struct ggml_backend_qnn_context * ctx       = nullptr;
 
     std::string qnn_graph_name                  = "ggml_qnn_graph";
-    std::string qnn_opconfig_name               = "ggml_qnn_opconfig";
+    std::string qnn_op_config_name               = "ggml_qnn_op_config";
     const char * qnn_op_name                    = nullptr;
     Qnn_GraphHandle_t graph_handle              = nullptr;
     Qnn_Tensor_t * tensor_0                     = nullptr;
@@ -3105,33 +2987,32 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
     Qnn_Tensor_t * tensor_2                     = nullptr;
 
     Qnn_QuantizeParams_t quantize_param         = QNN_QUANTIZE_PARAMS_INIT;
-    Qnn_OpConfig_t qnn_opconfig                 = QNN_OPCONFIG_INIT;
+    Qnn_OpConfig_t qnn_op_config                 = QNN_OPCONFIG_INIT;
     Qnn_Param_t qnn_params[]                    = {};
 
     Qnn_DataType_t src0_qnn_type                = QNN_DATATYPE_FLOAT_32;
     Qnn_DataType_t src1_qnn_type                = QNN_DATATYPE_FLOAT_32;
     Qnn_DataType_t dst_qnn_type                 = QNN_DATATYPE_FLOAT_32;
 
-
     if ((nullptr == src0) || (nullptr == src1) || (nullptr == dst)) {
-        LOGGW("pls check why GGML tensor is null");
+        QNN_LOG_WARN("pls check why GGML tensor is null");
         return;
     }
     tensor_0                                    = (Qnn_Tensor_t *)src0->extra;
     tensor_1                                    = (Qnn_Tensor_t *)src1->extra;
     tensor_2                                    = (Qnn_Tensor_t *)dst->extra;
     if ((nullptr == tensor_0) || (nullptr == tensor_1) || (nullptr == tensor_2)) {
-        LOGGW("pls check why QNN tensor is null");
+        QNN_LOG_WARN("pls check why QNN tensor is null");
         return;
     }
     ctx                                         = (struct ggml_backend_qnn_context *)g_qnn_backend->context;
     if (nullptr == ctx) {
-        LOGGW("pls check why backend ctx is null");
+        QNN_LOG_WARN("pls check why backend ctx is null");
         return;
     }
     instance                                    = ctx->instance;
     if (nullptr == instance) {
-        LOGGW("pls check why qnn instance is null");
+        QNN_LOG_WARN("pls check why qnn instance is null");
         return;
     }
     QNN_INTERFACE_VER_TYPE qnn_raw_interface    = ctx->raw_interface;
@@ -3141,28 +3022,30 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
     dst_qnn_type                                = qnn_datatype_from_ggml_datatype(dst->type);
     qnn_op_name                                 = qnn_opname_from_ggmlop(ggmlop);
     if (nullptr == qnn_op_name) {
-        LOGGW("pls check why can not get QNN OP name with ggml op %d(%s)", ggmlop, ggml_op_name(ggmlop));
+        QNN_LOG_WARN("pls check why can not get QNN OP name with ggml op %d(%s)", ggmlop, ggml_op_name(ggmlop));
         return;
     }
 
     n_begin_time                                = ggml_time_us();
-    LOGGD("call %s\n", __func__);
-    LOGGI("%15s: rank = %d, type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src0->name, src0->rank,
+#if 1
+    QNN_LOG_DEBUG("call %s\n", __func__);
+    QNN_LOG_DEBUG("%15s: type = %i (%5s)  ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src0->name,
           src0->type, ggml_type_name(src0->type), src0->ne[0], src0->ne[1], src0->ne[2],
           src0->nb[0], src0->nb[1], src0->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          src1->name, src1->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          src1->name,
           src1->type, ggml_type_name(src1->type), src1->ne[0], src1->ne[1], src1->ne[2],
           src1->nb[0], src1->nb[1], src1->nb[2]);
-    LOGGI("%15s: rank = %d, type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
-          dst->name, dst->rank,
+    QNN_LOG_DEBUG("%15s: type = %i (%5s) ne = %5" PRIi64 " x %5" PRIi64 " x %5" PRIi64 ", nb = (%5zi, %5zi, %5zi)\n",
+          dst->name,
           dst->type, ggml_type_name(dst->type), dst->ne[0], dst->ne[1], dst->ne[2], dst->nb[0],
           dst->nb[1], dst->nb[2]);
-    LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
-    LOGGD("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
-    LOGGD("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
-    LOGGD("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
+    QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+    QNN_LOG_DEBUG("tensor0 name %s", QNN_TENSOR_GET_NAME(tensor_0));
+    QNN_LOG_DEBUG("tensor1 name %s", QNN_TENSOR_GET_NAME(tensor_1));
+    QNN_LOG_DEBUG("tensor2 name %s", QNN_TENSOR_GET_NAME(tensor_2));
+#endif
 
     QNN_VER_PTR(*tensor_0)->type = QNN_TENSOR_TYPE_APP_WRITE;
     QNN_VER_PTR(*tensor_1)->type = QNN_TENSOR_TYPE_APP_WRITE;
@@ -3184,26 +3067,26 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
 
     if (!graph_initialized) {
         qnn_graph_name = qnn_graph_name + "_" + ggml_op_name(ggmlop) + std::to_string(ctx->threads) + src0->name + "_" + src1->name;
-        qnn_opconfig_name = qnn_opconfig_name + "_" + ggml_op_name(ggmlop) + std::to_string(ctx->threads) + src0->name + "_" + src1->name;
-        LOGGD("qnn graph name %s", qnn_graph_name.c_str());
-        LOGGD("qnn opconfig name %s", qnn_opconfig_name.c_str());
+        qnn_op_config_name = qnn_op_config_name + "_" + ggml_op_name(ggmlop) + std::to_string(ctx->threads) + src0->name + "_" + src1->name;
+        QNN_LOG_DEBUG("qnn graph name %s", qnn_graph_name.c_str());
+        QNN_LOG_DEBUG("qnn op_config name %s", qnn_op_config_name.c_str());
         error = qnn_raw_interface.graphCreate(instance->get_qnn_context_handle(), qnn_graph_name.c_str(), nullptr, &graph_handle);
         if (QNN_SUCCESS != error) {
-            LOGGI("can't create qnn graph handle with ggml op %s, graph name %s, error = %d\n", ggml_op_name(ggmlop), qnn_graph_name.c_str(), error);
+            QNN_LOG_INFO("can't create qnn graph handle with ggml op %s, graph name %s, error = %d\n", ggml_op_name(ggmlop), qnn_graph_name.c_str(), error);
             return;
         }
 
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_0);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_1);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.tensorCreateGraphTensor(graph_handle, tensor_2);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
 
         QNN_VER_PTR(*tensor_0)->clientBuf = {src0->data, ggml_get_tensor_data_size(src0)};
@@ -3217,9 +3100,9 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
         Qnn_Tensor_t tensor_outputs[] = {
                 *tensor_2
         };
-        Qnn_OpConfig_t opconfig = {
+        Qnn_OpConfig_t op_config = {
                 (Qnn_OpConfigVersion_t) 1, .v1 = {
-                        qnn_opconfig_name.c_str(),
+                        qnn_op_config_name.c_str(),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         qnn_op_name,
                         0,
@@ -3230,17 +3113,17 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
                         tensor_outputs
                 }
         };
-        error = qnn_raw_interface.graphAddNode(graph_handle, opconfig);
+        error = qnn_raw_interface.graphAddNode(graph_handle, op_config);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphFinalize(graph_handle, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
         auto  graph_item = std::make_tuple(graph_handle, tensor_0, tensor_1, tensor_2);
         instance->_qnn_graph_map[map_entry] = graph_item;
@@ -3251,7 +3134,7 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
         tensor_1     = std::get<2>(graph_item);
         tensor_2     = std::get<3>(graph_item);
 
-        LOGGD("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
+        QNN_LOG_DEBUG("%d, %d, %d, %d", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
         uint32_t dimensions_input_0[] = {(uint32_t) src0->ne[0], (uint32_t) src0->ne[1],
                                          (uint32_t) src0->ne[2], (uint32_t) src0->ne[3]};
         uint32_t dimensions_input_1[] = {(uint32_t) src1->ne[0], (uint32_t) src1->ne[1],
@@ -3281,156 +3164,153 @@ static void ggml_qnn_hanlde_op(const enum ggml_op ggmlop, const ggml_tensor * sr
         };
         error = qnn_raw_interface.graphExecute(graph_handle, tensor_inputs, 2, tensor_outputs, 1, nullptr, nullptr);
         if (QNN_SUCCESS != error) {
-            LOGGI("error = %d\n", error);
+            QNN_LOG_INFO("error = %d\n", error);
         }
     }
     n_end_time = ggml_time_us();
     n_durtion = (n_end_time - n_begin_time) / 1000;
-    LOGGD("duration of ggml_qnn_%s : %lld milliseconds\n", ggml_op_name(ggmlop), n_durtion);
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("duration of ggml_qnn_%s : %lld milliseconds\n", ggml_op_name(ggmlop), n_durtion);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_repeat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_get_rows(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_acc(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
-
-
-
 static void ggml_qnn_div(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_gelu(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_silu(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_gelu_quick(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_tanh(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_relu(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_hardsigmoid(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_hardswish(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_leaky_relu(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_sqr(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_norm(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_group_norm(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_concat(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_upscale(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_pad(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_rms_norm(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_cpy(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
@@ -3443,83 +3323,76 @@ static void ggml_qnn_dup(const ggml_tensor * src0, const ggml_tensor * src1, ggm
 static void ggml_qnn_mul_mat_id(const ggml_tensor * src0,
                                 const ggml_tensor * src1,
                                 ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_scale(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_clamp(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_diag_mask_inf(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_soft_max(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_rope(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(ggml_is_contiguous(src0));
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 
-}
-
-
-static void ggml_qnn_alibi(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
-
-    LOGGD("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_pool2d(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_im2col(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_sum_rows(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(ggml_is_contiguous(src0));
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 static void ggml_qnn_argsort(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(ggml_is_contiguous(src0));
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
@@ -3527,56 +3400,33 @@ static void ggml_qnn_nop(const ggml_tensor * src0, const ggml_tensor * src1, ggm
     (void) src0;
     (void) src1;
     (void) dst;
-    LOGGD("call %s\n", __func__);
+    QNN_LOG_DEBUG("call %s\n", __func__);
 
-    LOGGD("call %s done\n", __func__);
+    QNN_LOG_DEBUG("call %s done\n", __func__);
 }
 
 
 bool ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor) {
-    ENTER_FUNC();
     ggml_qnn_func_t func                = nullptr;
     ggml_qnn_func_common_t  func_common = nullptr;
 
-    bool supported_op                   = false;
-
+#if 1// NOT_IN_PR // not in PR, should be removed before PR because this is a workaround method during development stage
     bool use_hwaccel                    = false;
-
-    //begin sanity check
-    if (nullptr == g_qnn_backend) {
-        LOGGE("pls check why qnn subsystem not initialized");
-        return false;
-    }
-
-    //attention here:
-    //this is special scenario for UT function qnn_ggml_op
-    //borrow some advantages from PyTorch:the user or the upper layer codes could specify whether a GGML OP(such as add/mul/mulmat) is accelerated by a specify backend)
-    //otherwise ggml-qnn.cpp don't known whether current caller is whisper.cpp or other scenario(for example, JNI function...)
-
-    //in the all, use_hwaccel is different with supported_op
-    //this feature is heavily depend on PR in upstream whisper.cpp https://github.com/ggerganov/whisper.cpp/pull/2073
     use_hwaccel = (tensor->src[0]->backend == GGML_BACKEND_TYPE_GPU);
-
-    supported_op = ((tensor->op == GGML_OP_ADD) || (tensor->op == GGML_OP_MUL) || (tensor->op == GGML_OP_MUL_MAT));
-    //supported_op = (tensor->op == GGML_OP_ADD); //works very good with whisper.cpp(asr result is correct)
-
-    if ((!use_hwaccel) && (!supported_op)) {
-        //TODO: should be removed because this is a workaround method during development stage
+    bool supported_op = ((tensor->op == GGML_OP_ADD) || (tensor->op == GGML_OP_MUL) || (tensor->op == GGML_OP_MUL_MAT));
+    if (!use_hwaccel && !supported_op) {
         ggml_compute_forward(params, tensor, nullptr);
         return false;
     }
-
-    if ((!use_hwaccel) && (!ggml_qnn_can_handle_op(tensor->src[0], tensor->src[1], tensor))) {
-        //TODO: should be removed because this is a workaround method during development stage
+    if ((!use_hwaccel) && (!ggml_qnn_can_handle_op(tensor, false))) {
         ggml_compute_forward(params, tensor, nullptr);
         return false;
     }
-    //end sanity check
+#endif
 
     switch (tensor->op) {
         case GGML_OP_ADD:
             func = ggml_qnn_add;
-            //func_common = ggml_qnn_hanlde_op;
             break;
 
         case GGML_OP_MUL:
@@ -3585,7 +3435,6 @@ bool ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_t
 
         case GGML_OP_MUL_MAT:
             func = ggml_qnn_mul_mat;
-            //func_common = ggml_qnn_hanlde_op;
             break;
 
         case GGML_OP_REPEAT:
@@ -3654,7 +3503,6 @@ bool ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_t
         case GGML_OP_RMS_NORM:
             func = ggml_qnn_rms_norm;
             break;
-
         case GGML_OP_MUL_MAT_ID:
             func = ggml_qnn_mul_mat_id;
             break;
@@ -3707,10 +3555,9 @@ bool ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_t
 
     if (nullptr != func)
         func(tensor->src[0], tensor->src[1], tensor);
+
     if (nullptr != func_common)
         func_common(tensor->op, tensor->src[0], tensor->src[1], tensor);
-
-    LEAVE_FUNC();
 
     return true;
 }
@@ -3718,7 +3565,6 @@ bool ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_t
 
 struct ggml_backend_qnn_buffer_context {
     ~ggml_backend_qnn_buffer_context() {
-        //ENTER_FUNC();
         if (buffer) {
             free(buffer);
         }
@@ -3727,7 +3573,6 @@ struct ggml_backend_qnn_buffer_context {
         }
 
         for (auto * qnn_tensor : qnn_tensors) {
-            //LOGGD("tensor name %s", QNN_TENSOR_GET_NAME(qnn_tensor));
             free_qnn_tensor(*qnn_tensor);
             free(qnn_tensor);
         }
@@ -3738,19 +3583,12 @@ struct ggml_backend_qnn_buffer_context {
         for (graph_it = backend_ctx->instance->_qnn_graph_map.begin(); graph_it != backend_ctx->instance->_qnn_graph_map.end(); graph_it++) {
             auto & graph_item = graph_it->second;
             Qnn_GraphHandle_t & graph_handle = std::get<0>(graph_item);
-            LOGGD("graph type:%s", graph_it->first.c_str());
-            //QnnGraph_Property_t graph_prop;
-            //graph_prop.option = QNN_GRAPH_PROPERTY_OPTION_CUSTOM;
-            //QnnGraph_Property_t * p_graph_prop = &graph_prop;
-            //qnn_raw_interface.graphGetProperty(graph_handle, &p_graph_prop);
-            //LOGGD("graph name %s", (char*)p_graph_prop->customProperty);
+            QNN_LOG_DEBUG("graph type:%s", graph_it->first.c_str());
         }
-        //TODO:refine it
         backend_ctx->instance->_qnn_graph_map.clear();
 
         sub_buffers.clear();
         qnn_tensors.clear();
-        //LEAVE_FUNC();
     }
     void * buffer       = nullptr;
 
@@ -3761,28 +3599,24 @@ struct ggml_backend_qnn_buffer_context {
     std::vector<Qnn_Tensor_t *> qnn_tensors;
 };
 
+
 static const char * ggml_backend_qnn_buffer_get_name(ggml_backend_buffer_t buffer) {
     GGML_UNUSED(buffer);
     return "QNN";
 }
 
 
-GGML_CALL static bool ggml_backend_buffer_is_qnn(ggml_backend_buffer_t buffer) {
-    ENTER_FUNC();
-    LEAVE_FUNC();
+[[maybe_unused]] GGML_CALL static bool ggml_backend_buffer_is_qnn(ggml_backend_buffer_t buffer) {
     return buffer->iface.get_name == ggml_backend_qnn_buffer_get_name;
 }
 
 
 static void ggml_backend_qnn_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-    ENTER_FUNC();
     ggml_backend_qnn_buffer_context * ctx = (ggml_backend_qnn_buffer_context *) buffer->context;
     delete ctx;
-    LEAVE_FUNC();
 }
 
 
-//TODO
 static void * ggml_backend_qnn_buffer_get_base(ggml_backend_buffer_t buffer) {
     ggml_backend_qnn_buffer_context * ctx = (ggml_backend_qnn_buffer_context *) buffer->context;
 
@@ -3791,34 +3625,17 @@ static void * ggml_backend_qnn_buffer_get_base(ggml_backend_buffer_t buffer) {
 
 
 static void ggml_backend_qnn_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
-    //ENTER_FUNC();
     Qnn_ErrorHandle_t error = QNN_SUCCESS;
     ggml_backend_qnn_buffer_context * ctx = (ggml_backend_qnn_buffer_context *)buffer->context;
-
-    /*
-    if (tensor->view_src != nullptr && tensor->view_offs == 0) {
-        assert(tensor->view_src->buffer->buft == buffer->buft);
-        tensor->backend = tensor->view_src->backend;
-        tensor->extra = tensor->view_src->extra;
-        LOGGD("init tensor did nothing");
-        return;
-    }
-    */
 
     uint32_t dimensions[] = {(uint32_t) tensor->ne[0], (uint32_t) tensor->ne[1], (uint32_t) tensor->ne[2], (uint32_t) tensor->ne[3]};
     //TODO:only support FP32 & FP16
     Qnn_DataType_t  qnn_data_type = QNN_DATATYPE_FLOAT_32;
     Qnn_TensorType_t qnn_tensor_type = QNN_TENSOR_TYPE_APP_WRITE;
 
-
-    //LOGGD("tensor name %s", tensor->name);
-    //LOGGD("tensor data %p", tensor->data);
-
     if (tensor->flags & GGML_TENSOR_FLAG_INPUT) {
-        //LOGGD("input tensor");
         qnn_tensor_type = QNN_TENSOR_TYPE_APP_WRITE;
     } else if (tensor->flags & GGML_TENSOR_FLAG_OUTPUT) {
-        LOGGD("output tensor");
         qnn_tensor_type = QNN_TENSOR_TYPE_APP_READ;
     }
     Qnn_Tensor_t  qnn_tensor = {
@@ -3840,45 +3657,31 @@ static void ggml_backend_qnn_buffer_init_tensor(ggml_backend_buffer_t buffer, gg
     };
     Qnn_Tensor_t  * p_qnn_tensor = (Qnn_Tensor_t *)malloc(sizeof(Qnn_Tensor_t));
     if (nullptr == p_qnn_tensor) {
-        LOGGW("init tensor failed");
+        QNN_LOG_WARN("init tensor failed");
         return;
     }
     Qnn_Tensor_t tensor_copy;
     error = deep_copy_qnn_tensors(qnn_tensor, *p_qnn_tensor);
     if (error != QNN_SUCCESS) {
         free(p_qnn_tensor);
-        LOGGD("init tensor failed");
+        QNN_LOG_DEBUG("init tensor failed");
         return;
     }
     tensor->extra = p_qnn_tensor;
     ctx->qnn_tensors.push_back(p_qnn_tensor);
-
-    if (ggml_is_quantized(tensor->type)) {
-        //TODO
-        LOGGD("is quantized");
-    }
-    LEAVE_FUNC();
 }
 
 
 static void ggml_backend_qnn_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
-    //ENTER_FUNC();
     GGML_UNUSED(buffer);
 
-    //LOGGD("tensor name: %s, size %d", tensor->name, size);
     memcpy((char *)tensor->data + offset, data, size);
-
-    //LEAVE_FUNC();
 }
 
 
 static void ggml_backend_qnn_buffer_get_tensor(ggml_backend_buffer_t buffer, const ggml_tensor * tensor, void * data, size_t offset, size_t size) {
-    //ENTER_FUNC();
     GGML_UNUSED(buffer);
-    //LOGGD("tensor name: %s, size %d", tensor->name, size);
     memcpy(data, (const char *)tensor->data + offset, size);
-
-    //LEAVE_FUNC();
 }
 
 
@@ -3888,28 +3691,24 @@ static bool ggml_backend_qnn_buffer_cpy_tensor(ggml_backend_buffer_t buffer, con
         memcpy(dst->data, src->data, ggml_nbytes(src));
         return true;
     }
+
     return false;
 }
 
 
 static void ggml_backend_qnn_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
-    //ENTER_FUNC();
     ggml_backend_qnn_buffer_context * ctx = (ggml_backend_qnn_buffer_context *) buffer->context;
 
     memset(ctx->buffer, value, ctx->buffer_size);
-    //LEAVE_FUNC();
 }
 
 
-
 static void ggml_backend_qnn_buffer_reset(ggml_backend_buffer_t buffer) {
-    ENTER_FUNC();
     ggml_backend_qnn_buffer_context * ctx = (ggml_backend_qnn_buffer_context *) buffer->context;
     for (auto * sub_buffer : ctx->sub_buffers) {
         free(sub_buffer);
     }
     ctx->sub_buffers.clear();
-    LEAVE_FUNC();
 }
 
 
@@ -3927,8 +3726,6 @@ static ggml_backend_buffer_i ggml_backend_qnn_buffer_interface = {
 
 
 static const char * ggml_backend_qnn_buffer_type_name(ggml_backend_buffer_type_t buft) {
-    ENTER_FUNC();
-    LEAVE_FUNC();
     return "QNN";
 }
 
@@ -3937,7 +3734,7 @@ static void * ggml_qnn_host_malloc(size_t n) {
     void * data = nullptr;
     const int result = posix_memalign((void **) &data, sysconf(_SC_PAGESIZE), n);
     if (result != 0) {
-        LOGGW("%s: error: posix_memalign failed\n", __func__);
+        QNN_LOG_WARN("%s: error: posix_memalign failed\n", __func__);
         return nullptr;
     }
 
@@ -3945,10 +3742,7 @@ static void * ggml_qnn_host_malloc(size_t n) {
 }
 
 
-//TODO
 static ggml_backend_buffer_t ggml_backend_qnn_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
-    //ENTER_FUNC();
-
     ggml_backend_qnn_buffer_context * ctx = new ggml_backend_qnn_buffer_context;
 
     const size_t size_page = sysconf(_SC_PAGESIZE);
@@ -3958,22 +3752,16 @@ static ggml_backend_buffer_t ggml_backend_qnn_buffer_type_alloc_buffer(ggml_back
         size_aligned += (size_page - (size_aligned % size_page));
     }
 
-    //LOGGD("size %d, %d MB", size_aligned, size_aligned / (1 << 20));
-
     //TODO:use pre-allocated buffer in internal memory pool
     ctx->buffer = ggml_qnn_host_malloc(size_aligned);
     ctx->buffer_size = size_aligned;
 
-    //TODO:
-    LOGGD("device idx:%d", g_current_device);
     ctx->backend_ctx = &g_qnn_mgr[g_current_device];
 
     if (nullptr == ctx->buffer) {
-        LOGGW("%s: failed to allocate %.2f MiB\n", __func__, size / (1 << 20));
-        LEAVE_FUNC();
+        QNN_LOG_WARN("%s: failed to allocate %.2f MiB\n", __func__, size / (1 << 20));
         return nullptr;
     }
-    //LEAVE_FUNC();
 
     return ggml_backend_buffer_init(buft, ggml_backend_qnn_buffer_interface, ctx, size);
 }
@@ -3985,33 +3773,27 @@ static size_t ggml_backend_qnn_buffer_type_get_alignment(ggml_backend_buffer_typ
 }
 
 
-//TODO: this value is an experimental value
+//TODO: this value is an experimental value, works fine with whisper/llm/minicpm-v inference on Android
 static size_t ggml_backend_qnn_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
     GGML_UNUSED(buft);
-    //works fine with ggml-tiny.en-q8_0.bin for whisper.cpp
-    //return (38 * 1024 * 1024);
+
     return (96 * 1024 * 1024);
 }
 
 
 static bool ggml_backend_qnn_buffer_type_supports_backend(ggml_backend_buffer_type_t buft,
                                                           ggml_backend_t backend) {
-    ENTER_FUNC();
     GGML_UNUSED(buft);
-    LEAVE_FUNC();
 
     return ggml_backend_is_qnn(backend) || ggml_backend_is_cpu(backend);
 }
 
 
-// attention here because Qualcomm's QNN SDK is a highly well-designed SDK
-//
-// refer to https://developer.qualcomm.com/sites/default/files/attachments/qnn_software_stack.png
-//          https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-50/overview.html
 static bool ggml_backend_qnn_buffer_is_host(ggml_backend_buffer_type_t buft) {
     GGML_UNUSED(buft);
     return true;
 }
+
 
 static ggml_backend_buffer_type_i ggml_backend_qnn_buffer_type_interface = {
         /* .get_name         = */ ggml_backend_qnn_buffer_type_name,
@@ -4030,9 +3812,9 @@ static const char * ggml_backend_qnn_name(ggml_backend_t backend) {
 
 
 static void ggml_backend_qnn_free(ggml_backend_t backend) {
-    LOGGI("enter %s", __func__ );
+    QNN_LOG_INFO("enter %s", __func__ );
     ggml_backend_qnn_context * ctx = (ggml_backend_qnn_context *) backend->context;
-    LOGGD("idx %d, name:%s", ctx->device, g_qnn_mgr[ctx->device].name);
+    QNN_LOG_DEBUG("idx %d, name:%s", ctx->device, g_qnn_mgr[ctx->device].name);
 
     qnn_instance * instance = (qnn_instance*)g_qnn_mgr[ctx->device].instance;
     if (instance != nullptr) {
@@ -4041,158 +3823,30 @@ static void ggml_backend_qnn_free(ggml_backend_t backend) {
         g_qnn_mgr[ctx->device].instance = nullptr;
     }
 
+#if NOT_IN_PR
     qnn_buf_t * buffer_pool = (qnn_buf_t*)g_qnn_mgr[ctx->device].buffer_pool;
     if (buffer_pool != nullptr) {
         buffer_pool->destroy(buffer_pool);
         g_qnn_mgr[ctx->device].buffer_pool = nullptr;
     }
+#endif
 
     if (g_qnn_mgr[ctx->device].backend      != nullptr) {
         delete backend;
         g_qnn_backend = nullptr;
         g_qnn_mgr[ctx->device].backend = nullptr;
     }
-    LOGGI("leave %s", __func__ );
+    QNN_LOG_INFO("leave %s", __func__ );
 }
 
 
 static ggml_backend_buffer_type_t ggml_backend_qnn_get_default_buffer_type(ggml_backend_t backend) {
-    //ENTER_FUNC();
     ggml_backend_qnn_context * ctx = (ggml_backend_qnn_context *) backend->context;
-    //LOGGD("device %d,%s", ctx->device, ctx->name);
-    //LEAVE_FUNC();
 
     return ggml_backend_qnn_buffer_type(ctx->device);
 }
 
 
-#if 0
-static bool ggml_backend_qnn_supports_op(ggml_backend_t backend, const ggml_tensor * op) {
-    ENTER_FUNC();
-
-    GGML_UNUSED(backend);
-
-    switch (op->op) {
-        case GGML_OP_UNARY:
-            switch (ggml_get_unary_op(op)) {
-                case GGML_UNARY_OP_GELU:
-                case GGML_UNARY_OP_SILU:
-                case GGML_UNARY_OP_RELU:
-                case GGML_UNARY_OP_HARDSIGMOID:
-                case GGML_UNARY_OP_HARDSWISH:
-                case GGML_UNARY_OP_GELU_QUICK:
-                case GGML_UNARY_OP_TANH:
-                    return true;
-                default:
-                    return false;
-            }
-            break;
-        case GGML_OP_MUL_MAT:
-        case GGML_OP_MUL_MAT_ID: {
-            struct ggml_tensor *a;
-            struct ggml_tensor *b;
-            if (op->op == GGML_OP_MUL_MAT) {
-                a = op->src[0];
-                b = op->src[1];
-            } else {
-                a = op->src[2];
-                b = op->src[1];
-            }
-            if (a->ne[3] != b->ne[3]) {
-                return false;
-            }
-            ggml_type a_type = a->type;
-            if (a_type == GGML_TYPE_IQ4_NL || a_type == GGML_TYPE_IQ2_S ||
-                a_type == GGML_TYPE_IQ4_XS) {
-                return false;
-            }
-            return true;
-        }
-            break;
-        case GGML_OP_GET_ROWS: {
-            switch (op->src[0]->type) {
-                case GGML_TYPE_F16:
-                case GGML_TYPE_F32:
-                case GGML_TYPE_Q4_0:
-                case GGML_TYPE_Q4_1:
-                case GGML_TYPE_Q5_0:
-                case GGML_TYPE_Q5_1:
-                case GGML_TYPE_Q8_0:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-            break;
-        case GGML_OP_CPY: {
-            ggml_type src0_type = op->src[0]->type;
-            ggml_type src1_type = op->src[1]->type;
-            if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F32) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F16) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_Q8_0) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_Q4_0) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_Q4_1) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F16 && src1_type == GGML_TYPE_F16) {
-                return true;
-            }
-            if (src0_type == GGML_TYPE_F16 && src1_type == GGML_TYPE_F32) {
-                return true;
-            }
-            return false;
-        }
-            break;
-        case GGML_OP_CONCAT: {
-            ggml_type src0_type = op->src[0]->type;
-            return src0_type != GGML_TYPE_I32 && src0_type != GGML_TYPE_I16;
-        }
-            break;
-        case GGML_OP_DUP:
-        case GGML_OP_NONE:
-        case GGML_OP_RESHAPE:
-        case GGML_OP_REPEAT:
-        case GGML_OP_VIEW:
-        case GGML_OP_PERMUTE:
-        case GGML_OP_TRANSPOSE:
-        case GGML_OP_NORM:
-        case GGML_OP_ADD:
-        case GGML_OP_MUL:
-        case GGML_OP_DIV:
-        case GGML_OP_RMS_NORM:
-        case GGML_OP_SCALE:
-        case GGML_OP_SQR:
-        case GGML_OP_CLAMP:
-        case GGML_OP_CONT:
-        case GGML_OP_DIAG_MASK_INF:
-        case GGML_OP_SOFT_MAX:
-        case GGML_OP_ROPE:
-        case GGML_OP_ALIBI:
-        case GGML_OP_IM2COL:
-        case GGML_OP_POOL_2D:
-        case GGML_OP_SUM_ROWS:
-        case GGML_OP_ARGSORT:
-        case GGML_OP_ACC:
-        case GGML_OP_GROUP_NORM:
-        case GGML_OP_UPSCALE:
-        case GGML_OP_PAD:
-        case GGML_OP_LEAKY_RELU:
-            return true;
-        default:
-            return false;
-    }
-
-    LEAVE_FUNC();
-}
-# else
 static bool ggml_backend_qnn_supports_op(ggml_backend_t backend, const ggml_tensor * op) {
     GGML_UNUSED(backend);
 
@@ -4205,634 +3859,64 @@ static bool ggml_backend_qnn_supports_op(ggml_backend_t backend, const ggml_tens
             return false;
     }
 }
-#endif
 
 
-//TODO: implement all supported GGML OP using QNN API
-//PoC-S49: implementation of other GGML OP(non-mulmat) using QNN API
-//https://github.com/zhouwg/kantv/issues/121
 static ggml_status ggml_backend_qnn_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
-    //ENTER_FUNC();
     enum ggml_status result         = GGML_STATUS_SUCCESS;
     int node_n                      = -1;
-    int task_phase                  = GGML_TASK_TYPE_FINALIZE;
     ggml_backend_qnn_context * ctx  = (ggml_backend_qnn_context *) backend->context;
 
     struct ggml_cplan plan          = ggml_graph_plan(cgraph, 1);
-
-    buf_element_t * qnn_buf = nullptr;
-
     if (plan.work_size > 0) {
-        //LOGGI("work size %d(%d MB)", plan.work_size, plan.work_size / (1 << 20));
-        //plan.work_data = static_cast<uint8_t *>(malloc(plan.work_size));
+#if NOT_IN_PR
         plan.work_data = static_cast<uint8_t *>(ctx->buffer_pool->buffer_pool_base);
-        if (plan.work_data == nullptr) {
-            LOGGE("malloc failed");
-            return GGML_STATUS_FAILED;
+#else
+        plan.work_data = static_cast<uint8_t *>(malloc(plan.work_size));
+        if (nullptr == plan.work_data) {
+            QNN_LOG_ERROR("malloc failed");
+            return result;
         }
-    }
-    struct ggml_cplan * cplan = &plan;
-    GGML_ASSERT(cplan->n_threads > 0);
-    if (cplan->work_size > 0) {
-        GGML_ASSERT(cplan->work_data);
+#endif
     }
 
-    while (true) {
-        if (cplan->abort_callback && cplan->abort_callback(cplan->abort_callback_data)) {
-            result = GGML_STATUS_ABORTED;
-            break;
-        }
-        struct ggml_compute_params params = {
-                /*.type  =*/ GGML_TASK_TYPE_FINALIZE,
-                /*.ith   =*/ 0,
-                /*.nth   =*/ 0,
-                /*.wsize =*/ cplan->work_size,
-                /*.wdata =*/ cplan->work_data,
-        };
-
-        if (node_n != -1) {
-            /* FINALIZE */
-            struct ggml_tensor * node = cgraph->nodes[node_n];
-            if (GGML_OP_HAS_FINALIZE[node->op]) {
-                params.nth = 1;
-                ggml_qnn_compute_forward(&params, node);
-            }
-        }
-
-        while (++node_n < cgraph->n_nodes) {
-            //LOGGD("%s: %d/%d\n", __func__, node_n, cgraph->n_nodes);
-            struct ggml_tensor * node = cgraph->nodes[node_n];
-            params.nth = 1;
-            if (GGML_OP_HAS_INIT[node->op]) {
-                params.type = GGML_TASK_TYPE_INIT;
-                ggml_qnn_compute_forward(&params, node);
-            }
-            params.type = GGML_TASK_TYPE_COMPUTE;
+    struct ggml_compute_params params = {
+            /*.type  =*/ GGML_TASK_TYPE_FINALIZE,
+            /*.ith   =*/ 0,
+            /*.nth   =*/ 0,
+            /*.wsize =*/ plan.work_size,
+            /*.wdata =*/ plan.work_data,
+    };
+    while (++node_n < cgraph->n_nodes) {
+        struct ggml_tensor * node = cgraph->nodes[node_n];
+        params.nth = 1;
+        if (GGML_OP_HAS_INIT[node->op]) {
+            params.type = GGML_TASK_TYPE_INIT;
             ggml_qnn_compute_forward(&params, node);
-            if (GGML_OP_HAS_FINALIZE[node->op]) {
-                params.type = GGML_TASK_TYPE_FINALIZE;
-                ggml_qnn_compute_forward(&params, node);
-            }
-            if (cplan->abort_callback && cplan->abort_callback(cplan->abort_callback_data)) {
-                result = GGML_STATUS_ABORTED;
-                break;
-            }
         }
-        task_phase = GGML_TASK_TYPE_INIT;
-        if (node_n >= cgraph->n_nodes) {
-            //LOGGI("node_n %d", node_n);
-            //LOGGI("cgraph->n_nodes %d", cgraph->n_nodes);
-            break;
+        params.type = GGML_TASK_TYPE_COMPUTE;
+        ggml_qnn_compute_forward(&params, node);
+        if (GGML_OP_HAS_FINALIZE[node->op]) {
+            params.type = GGML_TASK_TYPE_FINALIZE;
+            ggml_qnn_compute_forward(&params, node);
         }
     }
 
-    //free(plan.work_data);
-    //LEAVE_FUNC();
+#if NOT_IN_PR
+    free(plan.work_data);
+#endif
 
     return result;
 }
 
 
-struct ggml_compute_state_shared {
-    const struct ggml_cgraph * cgraph;
-    const struct ggml_cplan  * cplan;
-
-    int64_t perf_node_start_cycles;
-    int64_t perf_node_start_time_us;
-
-    const int n_threads;
-
-    // synchronization primitives
-    atomic_int n_active;  // num active threads
-    atomic_int node_n;    // active graph node
-    atomic_int node_task; // active graph node task phase
-
-    ggml_abort_callback abort_callback; // abort ggml_graph_compute when true
-    void * abort_callback_data;
-};
-
-struct ggml_compute_state {
-    pthread_t thrd;
-    int ith;
-    struct ggml_compute_state_shared * shared;
-    enum ggml_status ec;
-};
-
-
-#ifdef GGML_PERF
-#define ggml_perf_time_ms()       ggml_time_ms()
-#define ggml_perf_time_us()       ggml_time_us()
-#define ggml_perf_cycles()        ggml_cycles()
-#define ggml_perf_cycles_per_ms() ggml_cycles_per_ms()
-#else
-#define ggml_perf_time_ms()       0
-#define ggml_perf_time_us()       0
-#define ggml_perf_cycles()        0
-#define ggml_perf_cycles_per_ms() 0
-#endif
-#undef MIN
-#undef MAX
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
-
-static void ggml_graph_compute_perf_stats_node(struct ggml_tensor * node, const struct ggml_compute_state_shared * st) {
-    int64_t cycles_cur  = ggml_perf_cycles()  - st->perf_node_start_cycles;
-    int64_t time_us_cur = ggml_perf_time_us() - st->perf_node_start_time_us;
-
-    node->perf_runs++;
-    node->perf_cycles  += cycles_cur;
-    node->perf_time_us += time_us_cur;
-}
-
-
-static void ggml_graph_compute_thread_sync_node(int * node_n, struct ggml_compute_state * state, const bool do_yield) {
-    // wait for other threads to finish
-    const int last_node_n = * node_n;
-
-    while (true) {
-        if (do_yield) {
-            sched_yield();
-        }
-
-        * node_n = atomic_load(&state->shared->node_n);
-        if (* node_n != last_node_n) break;
-    }
-}
-
-
-static void ggml_graph_compute_thread_sync_task(int * task_phase, struct ggml_compute_state * state, const bool do_yield) {
-    // wait for other threads to finish
-    const int last_task_phase = * task_phase;
-
-    while (true) {
-        if (do_yield) {
-            sched_yield();
-        }
-
-        * task_phase = atomic_load(&state->shared->node_task);
-        if (* task_phase != last_task_phase) break;
-    }
-}
-
-
-static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads, int n_cur_threads) {
-    int n_tasks = 0;
-
-    if (ggml_is_empty(node)) {
-        // no need to multi-thread a no-op
-        n_tasks = 1;
-        return n_tasks;
-    }
-
-    switch (node->op) {
-        case GGML_OP_CPY:
-        case GGML_OP_DUP:
-        case GGML_OP_ADD:
-        case GGML_OP_ADD1:
-        case GGML_OP_ACC: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_SUB:
-        case GGML_OP_SQR:
-        case GGML_OP_SQRT:
-        case GGML_OP_LOG:
-        case GGML_OP_SUM:
-        case GGML_OP_SUM_ROWS:
-        case GGML_OP_MEAN:
-        case GGML_OP_ARGMAX:
-        case GGML_OP_REPEAT:
-        case GGML_OP_REPEAT_BACK:
-        case GGML_OP_LEAKY_RELU: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_UNARY:
-            switch (ggml_get_unary_op(node)) {
-                case GGML_UNARY_OP_ABS:
-                case GGML_UNARY_OP_SGN:
-                case GGML_UNARY_OP_NEG:
-                case GGML_UNARY_OP_STEP:
-                case GGML_UNARY_OP_TANH:
-                case GGML_UNARY_OP_ELU:
-                case GGML_UNARY_OP_RELU:
-                case GGML_UNARY_OP_HARDSWISH:
-                case GGML_UNARY_OP_HARDSIGMOID: {
-                    n_tasks = 1;
-                }
-                    break;
-
-                case GGML_UNARY_OP_GELU:
-                case GGML_UNARY_OP_GELU_QUICK:
-                case GGML_UNARY_OP_SILU: {
-                    n_tasks = n_threads;
-                }
-                    break;
-                default:
-                    GGML_ASSERT(false);
-            }
-            break;
-        case GGML_OP_SILU_BACK:
-        case GGML_OP_MUL:
-        case GGML_OP_DIV:
-        case GGML_OP_NORM:
-        case GGML_OP_RMS_NORM:
-        case GGML_OP_RMS_NORM_BACK:
-        case GGML_OP_GROUP_NORM:
-        case GGML_OP_CONCAT: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_MUL_MAT: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_MUL_MAT_ID: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_OUT_PROD: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_GET_ROWS: {
-            n_tasks = MIN(n_cur_threads, ggml_nelements(node->src[1]));
-        }
-            break;
-        case GGML_OP_SCALE:
-        case GGML_OP_SET:
-        case GGML_OP_CONT:
-        case GGML_OP_RESHAPE:
-        case GGML_OP_VIEW:
-        case GGML_OP_PERMUTE:
-        case GGML_OP_TRANSPOSE:
-        case GGML_OP_GET_ROWS_BACK:
-        case GGML_OP_DIAG: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_DIAG_MASK_ZERO:
-        case GGML_OP_DIAG_MASK_INF:
-        case GGML_OP_SOFT_MAX_BACK:
-        case GGML_OP_ROPE:
-        case GGML_OP_ROPE_BACK:
-        case GGML_OP_ADD_REL_POS: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_CLAMP: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_SOFT_MAX: {
-            n_tasks = MIN(n_threads, ggml_nrows(node->src[0]));
-        }
-            break;
-        case GGML_OP_CONV_TRANSPOSE_1D: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_IM2COL: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_CONV_TRANSPOSE_2D: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_POOL_1D:
-        case GGML_OP_POOL_2D: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_UPSCALE: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_PAD: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_ARANGE: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_TIMESTEP_EMBEDDING: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_ARGSORT: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_FLASH_ATTN_BACK: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_SSM_CONV:
-        case GGML_OP_SSM_SCAN: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_WIN_PART:
-        case GGML_OP_WIN_UNPART:
-        case GGML_OP_GET_REL_POS:
-        case GGML_OP_MAP_UNARY:
-        case GGML_OP_MAP_BINARY:
-        case GGML_OP_MAP_CUSTOM1_F32:
-        case GGML_OP_MAP_CUSTOM2_F32:
-        case GGML_OP_MAP_CUSTOM3_F32: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_MAP_CUSTOM1: {
-            LOGGE("not support");
-        }
-            break;
-        case GGML_OP_MAP_CUSTOM2: {
-            LOGGE("not support");
-        }
-            break;
-        case GGML_OP_MAP_CUSTOM3: {
-            LOGGE("not support");
-        }
-            break;
-        case GGML_OP_CROSS_ENTROPY_LOSS: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_CROSS_ENTROPY_LOSS_BACK: {
-            n_tasks = n_threads;
-        }
-            break;
-        case GGML_OP_NONE: {
-            n_tasks = 1;
-        }
-            break;
-        case GGML_OP_COUNT: {
-            GGML_ASSERT(false);
-        }
-            break;
-        default: {
-            LOGGW("%s: op not implemented: ", __func__);
-            if (node->op < GGML_OP_COUNT) {
-                LOGGD("%s\n", ggml_op_name(node->op));
-            } else {
-                LOGGD("%d\n", node->op);
-            }
-            GGML_ASSERT(false);
-        }
-            break;
-    }
-
-    assert(n_tasks > 0);
-
-    return n_tasks;
-}
-
-
-static void * ggml_graph_compute_thread(void * data) {
-    struct ggml_compute_state * state = (struct ggml_compute_state *) data;
-
-    const struct ggml_cgraph * cgraph = state->shared->cgraph;
-    const struct ggml_cplan  * cplan  = state->shared->cplan;
-
-    const int   n_threads   = state->shared->n_threads;
-
-    int node_n     = -1;
-    int task_phase = GGML_TASK_TYPE_FINALIZE;
-
-    while (true) {
-        if (cplan->abort_callback && cplan->abort_callback(cplan->abort_callback_data)) {
-            state->shared->node_n += 1;
-            state->ec = GGML_STATUS_ABORTED;
-            return 0;
-        }
-
-        if (atomic_fetch_sub(&state->shared->n_active, 1) == 1) {
-            // all other threads are finished and spinning
-            // do finalize and init here so we don't have synchronize again
-            struct ggml_compute_params params = {
-                    /*.type  =*/ GGML_TASK_TYPE_FINALIZE,
-                    /*.ith   =*/ 0,
-                    /*.nth   =*/ 0,
-                    /*.wsize =*/ cplan->work_size,
-                    /*.wdata =*/ cplan->work_data,
-            };
-
-            if (node_n != -1) {
-                /* FINALIZE */
-                struct ggml_tensor * node = cgraph->nodes[node_n];
-                if (GGML_OP_HAS_FINALIZE[node->op]) {
-                    params.nth = ggml_get_n_tasks(node, n_threads, state->shared->n_threads);
-                    ggml_qnn_compute_forward(&params, node);
-                }
-                ggml_graph_compute_perf_stats_node(node, state->shared);
-            }
-
-            // distribute new work or execute it direct if 1T
-            while (++node_n < cgraph->n_nodes) {
-                //LOGGI("%s: %d/%d\n", __func__, node_n, cgraph->n_nodes);
-                struct ggml_tensor * node = cgraph->nodes[node_n];
-                const int n_tasks = ggml_get_n_tasks(node, n_threads, state->shared->n_threads);
-
-                state->shared->perf_node_start_cycles  = ggml_perf_cycles();
-                state->shared->perf_node_start_time_us = ggml_perf_time_us();
-
-                params.nth = n_tasks;
-
-                if (n_tasks == 1) {
-                    /* INIT */
-                    if (GGML_OP_HAS_INIT[node->op]) {
-                        params.type = GGML_TASK_TYPE_INIT;
-                        ggml_qnn_compute_forward(&params, node);
-                    }
-
-                    // TODO: maybe push node_n to the atomic but if other threads see n_tasks is 1,
-                    // they do something more efficient than spinning (?)
-                    params.type = GGML_TASK_TYPE_COMPUTE;
-                    ggml_qnn_compute_forward(&params, node);
-
-                    if (GGML_OP_HAS_FINALIZE[node->op]) {
-                        params.type = GGML_TASK_TYPE_FINALIZE;
-                        ggml_qnn_compute_forward(&params, node);
-                    }
-
-                    ggml_graph_compute_perf_stats_node(node, state->shared);
-                } else {
-                    break;
-                }
-
-                if (cplan->abort_callback && cplan->abort_callback(cplan->abort_callback_data)) {
-                    break;
-                }
-            }
-
-            task_phase = GGML_TASK_TYPE_INIT;
-            atomic_store(&state->shared->n_active,  n_threads);
-            atomic_store(&state->shared->node_n,    node_n);
-            atomic_store(&state->shared->node_task, task_phase);
-        } else {
-            ggml_graph_compute_thread_sync_node(&node_n,     state, false);
-            ggml_graph_compute_thread_sync_task(&task_phase, state, false);
-        }
-
-        // check if we should stop
-        if (node_n >= cgraph->n_nodes) break;
-
-        /* INIT & COMPUTE */
-        struct ggml_tensor * node = cgraph->nodes[node_n];
-        const int n_tasks = ggml_get_n_tasks(node, n_threads, state->shared->n_threads);
-
-        struct ggml_compute_params params = {
-                /*.type  =*/ GGML_TASK_TYPE_INIT,
-                /*.ith   =*/ state->ith,
-                /*.nth   =*/ n_tasks,
-                /*.wsize =*/ cplan->work_size,
-                /*.wdata =*/ cplan->work_data,
-        };
-
-        if (state->ith < n_tasks) {
-            if (GGML_OP_HAS_INIT[node->op]) {
-                ggml_qnn_compute_forward(&params, node);
-            }
-        }
-
-        if (atomic_fetch_sub(&state->shared->n_active, 1) == 1) {
-            task_phase = GGML_TASK_TYPE_COMPUTE;
-            atomic_store(&state->shared->n_active,  n_threads);
-            atomic_store(&state->shared->node_task, task_phase);
-        }
-        else {
-            const bool do_yield = node_n < 0 || cgraph->nodes[node_n]->op == GGML_OP_MUL_MAT;
-            ggml_graph_compute_thread_sync_task(&task_phase, state, do_yield);
-        }
-
-        if (state->ith < n_tasks) {
-            params.type = GGML_TASK_TYPE_COMPUTE;
-            ggml_qnn_compute_forward(&params, node);
-        }
-
-        if (atomic_fetch_sub(&state->shared->n_active, 1) == 1) {
-            task_phase = GGML_TASK_TYPE_FINALIZE;
-            atomic_store(&state->shared->n_active,  n_threads);
-            atomic_store(&state->shared->node_task, task_phase);
-        }
-        else {
-            ggml_graph_compute_thread_sync_task(&task_phase, state, false);
-        }
-    }
-
-    return 0;
-}
-
-
-static ggml_status ggml_backend_qnn_graph_compute_multithread(ggml_backend_t backend, ggml_cgraph * cgraph) {
-    //ENTER_FUNC();
-    ggml_backend_qnn_context * ctx  = (ggml_backend_qnn_context *) backend->context;
-    //LOGGD("device %d, thread %d\n", ctx->device, ctx->threads);
-
-    int num_threads = ctx->threads;
-
-    if (QNN_GPU == ctx->device || QNN_HTP == ctx->device) {
-        //TODO:multithreading not supported using QNN GPU/HTP(aka DSP) backend
-        num_threads = 1;
-    }
-    struct ggml_cplan plan          = ggml_graph_plan(cgraph, num_threads);
-
-
-    if (plan.work_size > 0) {
-        //LOGGI("work size %d(%d MB)", plan.work_size, plan.work_size / (1 << 20));
-        plan.work_data = static_cast<uint8_t *>(malloc(plan.work_size));
-        if (plan.work_data == nullptr) {
-            LOGGE("malloc failed");
-            return GGML_STATUS_FAILED;
-        }
-    }
-
-    struct ggml_cplan * cplan = &plan;
-    GGML_ASSERT(cplan->n_threads > 0);
-    if (cplan->work_size > 0) {
-        GGML_ASSERT(cplan->work_data);
-    }
-
-    //LOGGD("cgraph %p, cplan %p, work size %d, work data %p", cgraph, cplan, cplan->work_size, cplan->work_data);
-    const int n_threads = cplan->n_threads;
-
-    struct ggml_compute_state_shared state_shared = {
-            /*.cgraph                  =*/ cgraph,
-            /*.cgraph_plan             =*/ cplan,
-            /*.perf_node_start_cycles  =*/ 0,
-            /*.perf_node_start_time_us =*/ 0,
-            /*.n_threads               =*/ n_threads,
-            /*.n_active                =*/ n_threads,
-            /*.node_n                  =*/ -1,
-            /*.node_task               =*/ GGML_TASK_TYPE_FINALIZE,
-            /*.abort_callback          =*/ nullptr,
-            /*.abort_callback_data     =*/ nullptr,
-    };
-    struct ggml_compute_state * workers = (struct ggml_compute_state*)alloca(sizeof(struct ggml_compute_state) * n_threads);
-    if (nullptr == workers) {
-        LOGGE("malloc failed");
-        if (plan.work_data != nullptr) {
-            free(plan.work_data);
-        }
-        return GGML_STATUS_FAILED;
-    }
-
-    // create thread pool
-    if (n_threads > 1) {
-        for (int j = 1; j < n_threads; ++j) {
-            workers[j] = (struct ggml_compute_state) {
-                    .thrd   = 0,
-                    .ith = j,
-                    .shared = &state_shared,
-                    .ec = GGML_STATUS_SUCCESS,
-            };
-
-            const int rc = pthread_create(&workers[j].thrd, NULL, ggml_graph_compute_thread, &workers[j]);
-            GGML_ASSERT(rc == 0);
-        }
-    }
-
-    workers[0].ith = 0;
-    workers[0].shared = &state_shared;
-    workers[0].ec = GGML_STATUS_SUCCESS;
-
-    // this is a work thread too
-    ggml_graph_compute_thread(&workers[0]);
-    enum ggml_status compute_status = workers[0].ec;
-
-    // join or kill thread pool
-    if (n_threads > 1) {
-        for (int j = 1; j < n_threads; j++) {
-            const int rc = pthread_join(workers[j].thrd, NULL);
-            GGML_ASSERT(rc == 0);
-            if (workers[j].ec != GGML_STATUS_SUCCESS)
-                compute_status = workers[j].ec;
-        }
-    }
-
-    if (plan.work_data != nullptr) {
-        free(plan.work_data);
-    }
-    LEAVE_FUNC();
-    return compute_status;
-}
-
-
-static bool ggml_backend_qnn_offload_op(ggml_backend_t backend, const ggml_tensor * op) {
-    ENTER_FUNC();
+//note: this function will be used in new/proposal/refined ggml backend subsystem(will be available in a standalone PR)
+static bool ggml_backend_qnn_offload_op(ggml_backend_t backend, const ggml_tensor * tensor) {
     GGML_UNUSED(backend);
 
-    const int min_batch_size = 32;
-
-    LEAVE_FUNC();
-
-    return op->ne[1] >= min_batch_size && op->op != GGML_OP_GET_ROWS;
-
+    if (ggml_qnn_can_handle_op(tensor, false))
+        return true;
+    else
+        return false;
 }
 
 
@@ -4847,9 +3931,9 @@ static ggml_backend_i ggml_backend_qnn_interface = {
         /* .graph_plan_create       = */ nullptr,
         /* .graph_plan_free         = */ nullptr,
         /* .graph_plan_compute      = */ nullptr,
-        /* .graph_compute           = */ ggml_backend_qnn_graph_compute_multithread,
+        /* .graph_compute           = */ ggml_backend_qnn_graph_compute,
         /* .supports_op             = */ ggml_backend_qnn_supports_op,
-        /* .offload_op              = */ nullptr,
+        /* .offload_op              = */ ggml_backend_qnn_offload_op,
         /* .event_new               = */ nullptr,
         /* .event_free              = */ nullptr,
         /* .event_record            = */ nullptr,
@@ -4859,25 +3943,20 @@ static ggml_backend_i ggml_backend_qnn_interface = {
 
 
 static ggml_guid_t ggml_backend_qnn_guid() {
-    //ENTER_FUNC();
     static ggml_guid guid = {0x1a, 0x2b, 0x3c, 0x4d, 0x5e, 0x6f, 0x70, 0x81, 0x92, 0xa3, 0xb4, 0xc5,
                              0xd6, 0xe7, 0xf8, 0x09};
-    //LEAVE_FUNC();
-
     return &guid;
 }
 
 
 static ggml_backend_t ggml_backend_qnn_reg_init(const char * params, void * user_data) {
-    ENTER_FUNC();
-    if (nullptr == params) { // for QNN backend UT in command line mode
-        //this is data path of prebuit QNN libs provided by Qualcomm
-        //can be obtained through JNI from Java layer such as "/data/data/com.cdeos.kantv/qnnlib/"
-        //or hardcoded to "/data/local/tmp/" which is an Android OS defined path
+    if (nullptr == params) {
+        //QNN library path
+        //can be hardcoded to "/data/local/tmp/" for Android command line application
+        //or specified in Java/JNI layer for Android APK
         params = "/data/local/tmp/";
     }
     ggml_backend_t qnn_backend = ggml_backend_qnn_init((int) (intptr_t) user_data, params);
-    LEAVE_FUNC();
 
     return qnn_backend;
 }
@@ -4905,35 +3984,24 @@ int ggml_backend_qnn_get_device_count() {
 
 
 void ggml_backend_qnn_get_device_description(int device, char * description, size_t description_size) {
-    ENTER_FUNC();
     if (nullptr == description || 0 == description_size) {
-        LOGGW("invalid param");
+        QNN_LOG_WARN("invalid param");
         return;
     }
 
     if (device >= GGML_QNN_MAX_DEVICES) {
-        LOGGW("invalid param");
+        QNN_LOG_WARN("invalid param");
         return;
     }
 
     snprintf(description, description_size, "%s", g_qnn_mgr[device].name);
-    LOGGD("description:%s", description);
-
-    LEAVE_FUNC();
-}
-
-
-void ggml_backend_qnn_get_device_memory(int device, size_t * free, size_t * total) {
-    ENTER_FUNC();
-    LEAVE_FUNC();
+    QNN_LOG_DEBUG("description:%s", description);
 }
 
 
 ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device_index) {
-    //ENTER_FUNC();
-
     if (device_index >= GGML_QNN_MAX_DEVICES) {
-        LOGGD("ggml_backend_qnn_buffer_type error: device_index:%d is out of range [0, %d]\n",
+        QNN_LOG_DEBUG("ggml_backend_qnn_buffer_type error: device_index:%d is out of range [0, %d]\n",
                device_index, GGML_QNN_MAX_DEVICES - 1);
         return nullptr;
     }
@@ -4950,7 +4018,6 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device_index) {
             },
             /* .context = */ nullptr,
     };
-    //LEAVE_FUNC();
 
     return &ggml_backend_buffer_type_qnn;
 }
@@ -4958,32 +4025,31 @@ ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t device_index) {
 
 /**
  *
- * @param device            0: QNN_CPU 1: QNN_GPU 2: QNN_HTP(aka DSP)
- * @param qnn_lib_path      qnn library path, such as "/data/data/com.cdeos.kantv/qnnlib/" on Android
+ * @param device            0: QNN_BACKEND_CPU 1: QNN_BACKEND_GPU 2: QNN_BACKEND_NPU(aka HTP/DSP)
+ * @param qnn_lib_path      qnn library path, such as "/data/local/tmp/" on Android or APK's internal data path on Android
  * @return
  */
 ggml_backend_t ggml_backend_qnn_init(size_t device, const char * qnn_lib_path) {
-    ENTER_FUNC();
     int result = 0;
 
     if (nullptr == qnn_lib_path)
         return nullptr;
 
-    LOGGD("device %d", device);
-    LOGGD("qnn_lib_path %s", qnn_lib_path);
+    QNN_LOG_DEBUG("device %d", device);
+    QNN_LOG_DEBUG("qnn_lib_path %s", qnn_lib_path);
     if (device >= GGML_QNN_MAX_DEVICES) {
-        LOGGE("invalid device %d", device);
+        QNN_LOG_ERROR("invalid device %d", device);
         return nullptr;
     }
 
     if (nullptr != g_qnn_mgr[device].backend) {
-        LOGGE("qnn backend %d(%s) already loaded, it should not happened, pls check why?", device, get_qnn_backend_name(device));
+        QNN_LOG_ERROR("qnn backend %d(%s) already loaded, it should not happened, pls check why?", device, get_qnn_backend_name(device));
         if (device == g_current_device) {
             g_qnn_backend = g_qnn_mgr[device].backend;
-            LOGGI("re-use cached backend %d(%s)", device, get_qnn_backend_name(device));
+            QNN_LOG_INFO("re-use cached backend %d(%s)", device, get_qnn_backend_name(device));
             return g_qnn_mgr[device].backend;
         } else {
-            LOGGI("delete previous backend %d(%s)", device, get_qnn_backend_name(device));
+            QNN_LOG_INFO("delete previous backend %d(%s)", device, get_qnn_backend_name(device));
             ggml_backend_qnn_free(g_qnn_backend);
         }
     }
@@ -4994,23 +4060,23 @@ ggml_backend_t ggml_backend_qnn_init(size_t device, const char * qnn_lib_path) {
         is_first_call = false;
     }
 
-    if (QNN_HTP == device) {
+    if (QNN_BACKEND_NPU == device) {
         std::string path = qnn_lib_path;
         if (0 == setenv("LD_LIBRARY_PATH",
                         (path +
                          ":/vendor/dsp/cdsp:/vendor/lib64:/vendor/dsp/dsp:/vendor/dsp/images").c_str(),
                         1)) {
-            LOGGI("QNN DSP backend setenv successfully");
+            QNN_LOG_INFO("QNN DSP backend setenv successfully");
         } else {
-            LOGGE("QNN DSP backend setenv failure");
+            QNN_LOG_ERROR("QNN DSP backend setenv failure");
         }
         if (0 == setenv("ADSP_LIBRARY_PATH",
                         (path +
                          ";/vendor/dsp/cdsp;/vendor/lib/rfsa/adsp;/system/lib/rfsa/adsp;/vendor/dsp/dsp;/vendor/dsp/images;/dsp").c_str(),
                         1)) {
-            LOGGI("QNN DSP backend setenv successfully");
+            QNN_LOG_INFO("QNN DSP backend setenv successfully");
         } else {
-            LOGGE("QNN DSP backend setenv failure");
+            QNN_LOG_ERROR("QNN DSP backend setenv failure");
         }
     }
 
@@ -5018,26 +4084,28 @@ ggml_backend_t ggml_backend_qnn_init(size_t device, const char * qnn_lib_path) {
     instance = new qnn_instance(qnn_lib_path, g_qnn_mgr[device].lib, "");
     result = instance->qnn_init(nullptr);
     if (0 != result) {
-        LOGGW("init qnn subsystem failed with qnn backend %s, pls check why\n", get_qnn_backend_name(device));
+        QNN_LOG_WARN("init qnn subsystem failed with qnn backend %s, pls check why\n", get_qnn_backend_name(device));
         delete instance;
         return nullptr;
     }
     qnn_interface qnn_interface                             = instance->get_qnn_interface();
     if (!qnn_interface.is_loaded()) {
-        LOGGW("qnn subsystem failure\n");
+        QNN_LOG_WARN("qnn subsystem failure\n");
         delete instance;
         return nullptr;
     }
 
     std::string device_name = GGML_QNN_NAME + std::string("_") + std::to_string(device) + std::string("_") + get_qnn_backend_name(device);
-    LOGGI("qnn device name %s", device_name.c_str());
+    QNN_LOG_INFO("qnn device name %s", device_name.c_str());
     instance->init_qnn_graph(device_name.c_str(), false);
     g_qnn_mgr[device].instance                  = instance;
     g_qnn_mgr[device].raw_interface             = instance->get_qnn_raw_interface();
     g_qnn_mgr[device].raw_system_interface      = instance->get_qnn_raw_system_interface();
+#if NOT_IN_PR
     //TODO:refine internal buffer management
     g_qnn_mgr[device].buffer_pool               = qnn_buf_new(get_qnn_backend_name(device), GGML_QNN_MAX_BUFFERS, (1 << 20));
     GGML_ASSERT(g_qnn_mgr[device].buffer_pool != nullptr);
+#endif
 
     ggml_backend_t qnn_backend = new ggml_backend{
                 /* .guid      = */ ggml_backend_qnn_guid(),
@@ -5048,20 +4116,13 @@ ggml_backend_t ggml_backend_qnn_init(size_t device, const char * qnn_lib_path) {
     g_qnn_backend = g_qnn_mgr[device].backend;
     g_current_device = device;
 
-    LOGGI("get_default_buffer_type %p", qnn_backend->iface.get_default_buffer_type);//TODO:why the pointer changed with QNN GPU backend?
-    LOGGI("qnn_backend %p", qnn_backend);
-    LEAVE_FUNC();
-
     return qnn_backend;
 }
 
 
-extern "C" int ggml_backend_qnn_reg_devices();
-
+extern "C" int ggml_backend_qnn_reg_devices(void);
 
 int ggml_backend_qnn_reg_devices() {
-    ENTER_FUNC();
-
     for (size_t idx = 0; idx < GGML_QNN_MAX_DEVICES; idx++) {
         int id = g_qnn_mgr[idx].device;
         char name[GGML_MAX_NAME];
@@ -5070,6 +4131,5 @@ int ggml_backend_qnn_reg_devices() {
                               (void *) (intptr_t)idx);
     }
 
-    LEAVE_FUNC();
     return GGML_QNN_MAX_DEVICES;
 }

--- a/core/ggml/llamacpp/ggml-qnn.h
+++ b/core/ggml/llamacpp/ggml-qnn.h
@@ -28,19 +28,20 @@ extern "C" {
 #define GGML_QNN_NAME           "QNN"
 #define GGML_QNN_MAX_DEVICES    3
 
-//QNN cDSP and HTA backend would not be used currently, just focus on QNN CPU/GPU/HTP(aka DSP) backend currently
+//QNN cDSP and HTA backend would not be used currently, just focus on QNN CPU/GPU/NPU(aka HTP/DSP) backend currently
 enum QNNBackend {
-    QNN_CPU,
-    QNN_GPU,
-    QNN_HTP,
+    QNN_BACKEND_CPU,
+    QNN_BACKEND_GPU,
+    QNN_BACKEND_NPU,
+    QNN_BACKEND_GGML, //"fake" QNN backend just for compare performance between QNN and original GGML
 };
 
-GGML_API int            ggml_backend_qnn_reg_devices();
+GGML_API int            ggml_backend_qnn_reg_devices(void);
 
 /**
  *
- * @param device            0: QNN_CPU 1: QNN_GPU 2: QNN_HTP(aka DSP)
- * @param qnn_lib_path      qnn library path, such as "/data/data/com.cdeos.kantv/" on Android which can got by JNI from Java layer
+ * @param device            0: QNN_BACKEND_CPU 1: QNN_BACKEND_GPU 2: QNN_BACKEND_NPU(aka HTP/DSP)
+ * @param qnn_lib_path      qnn library path, such as "/data/local/tmp/" on Android or APK's internal data path on Android
  * @return
  */
 GGML_API ggml_backend_t ggml_backend_qnn_init(size_t dev_num, const char * qnn_lib_path);
@@ -50,15 +51,14 @@ GGML_API bool           ggml_backend_is_qnn(ggml_backend_t backend);
 GGML_API void           ggml_backend_qnn_set_n_threads(ggml_backend_t backend, int n_threads);
 
 GGML_API int            ggml_backend_qnn_get_device_count(void);
+
 GGML_API void           ggml_backend_qnn_get_device_description(int device, char * description, size_t description_size);
 
 
 GGML_API ggml_backend_buffer_type_t ggml_backend_qnn_buffer_type(size_t dev_num);
 
-
-//temporary API, should be removed in the future
+//temporary APIs, should be removed before PR to upstream
 GGML_API bool           ggml_qnn_compute_forward(struct ggml_compute_params * params, struct ggml_tensor * tensor);
-
 
 #ifdef __cplusplus
 }

--- a/core/ggml/llamacpp/tests/ggml-qnn/CMakeLists.txt
+++ b/core/ggml/llamacpp/tests/ggml-qnn/CMakeLists.txt
@@ -9,28 +9,24 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #set to ON if target Android phone is based on Qualcomm Snapdragon 8 Gen 3
 set(TARGET_SNAPDRAGON_8_GEN3        OFF)
 
-set(LLAMACPP_SRC_PATH               ${PROJECT_ROOT_PATH})
 set(QNN_INC_PATH                    ${QNN_SDK_PATH}/include/QNN)
 set(QNN_LIB_PATH                    ${QNN_SDK_PATH}/lib/aarch64-android)
 
 include_directories(${QNN_INC_PATH})
-include_directories(${LLAMACPP_SRC_PATH})
-include_directories(${LLAMACPP_SRC_PATH}/common)
-include_directories(${LLAMACPP_SRC_PATH}/../../../external/ffmpeg)
+include_directories(../../)  # ggml.h
+include_directories(../../../../../prebuilts/include/)  # cde_log.h
 
 set(SOURCE_FILES
-        ${LLAMACPP_SRC_PATH}/ggml.c
-        ${LLAMACPP_SRC_PATH}/ggml-alloc.c
-        ${LLAMACPP_SRC_PATH}/ggml-backend.c
-        ${LLAMACPP_SRC_PATH}/ggml-quants.c
-        ${LLAMACPP_SRC_PATH}/ggml-qnn.cpp
-        ${LLAMACPP_SRC_PATH}/tests/test-backend-ops.cpp
-        ${LLAMACPP_SRC_PATH}/../../../external/ffmpeg/libavutil/cde_log.c
+        ../../ggml.c
+        ../../ggml-alloc.c
+        ../../ggml-backend.c
+        ../../ggml-quants.c
+        ../../ggml-qnn.cpp
+        ../../../../../external/ffmpeg/libavutil/cde_log.c
+        ../test-backend-ops.cpp
 )
 
 
-message("PROJECT_ROOT_PATH    : ${PROJECT_ROOT_PATH}")
-message("LLAMACPP_SRC_PATH    : ${LLAMACPP_SRC_PATH}")
 message("QNN_SDK_PATH         : ${QNN_SDK_PATH}")
 message("QNN_INC_PATH         : ${QNN_INC_PATH}")
 message("QNN_LIB_PATH         : ${QNN_LIB_PATH}")
@@ -46,7 +42,7 @@ add_definitions(-O3)
 endif()
 
 if (TARGET_SNAPDRAGON_8_GEN3)
-# the below build optimization only works well on Qualcomm SM8650-AB Snapdragon 8 Gen 3
+# the below build optimization only verified and works well on Qualcomm SM8650-AB Snapdragon 8 Gen 3
 add_definitions(-march=armv8.7-a)
 add_definitions(-mcpu=cortex-x1)
 add_definitions(-mtune=cortex-x1)

--- a/core/ggml/llamacpp/tests/ggml-qnn/build-ggml-qnn.sh
+++ b/core/ggml/llamacpp/tests/ggml-qnn/build-ggml-qnn.sh
@@ -2,26 +2,18 @@
 
 set -e
 
-#modify following lines to adapt to local dev envs
-#for upstream PR
-#LLAMACPP_ROOT_PATH=~/github/llama.cpp/
-#for kantv
-LLAMACPP_ROOT_PATH=${PROJECT_ROOT_PATH}/core/ggml/llamacpp/
-#for upstream PR
-#ANDROID_NDK=`pwd`/android-ndk-r26c
 #https://qpm.qualcomm.com/#/main/tools/details/qualcomm_ai_engine_direct
 #https://developer.qualcomm.com/software/hexagon-dsp-sdk/tools
 QNN_SDK_PATH=/opt/qcom/aistack/qnn/2.20.0.240223/
 
+
+ANDROID_NDK=`pwd`/android-ndk-r26c
 ANDROID_PLATFORM=android-34
-#BUILD_TYPE=release
-BUILD_TYPE=debug
 TARGET=ggml-qnn-test
 
 
 function dump_vars()
 {
-    echo -e "LLAMACPP_ROOT_PATH:   ${LLAMACPP_ROOT_PATH}"
     echo -e "ANDROID_NDK:          ${ANDROID_NDK}"
     echo -e "QNN_SDK_PATH:         ${QNN_SDK_PATH}"
 }
@@ -30,6 +22,15 @@ function dump_vars()
 function show_pwd()
 {
     echo -e "current working path:$(pwd)\n"
+}
+
+
+function check_qnn_sdk()
+{
+    if [ ! -d ${QNN_SDK_PATH} ]; then
+        echo -e "QNN_SDK_PATH ${QNN_SDK_PATH} not exist, pls check...\n"
+        exit 1
+    fi
 }
 
 
@@ -67,7 +68,7 @@ function check_and_download_ndk()
 
 function build_arm64
 {
-    cmake -H. -B./out/arm64-v8a -DPROJECT_ROOT_PATH=${LLAMACPP_ROOT_PATH} -DTARGET_NAME=${TARGET} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=${ANDROID_PLATFORM} -DANDROID_NDK=${ANDROID_NDK}  -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DQNN_SDK_PATH=${QNN_SDK_PATH}
+    cmake -H. -B./out/arm64-v8a -DTARGET_NAME=${TARGET} -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=${ANDROID_PLATFORM} -DANDROID_NDK=${ANDROID_NDK}  -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DQNN_SDK_PATH=${QNN_SDK_PATH}
 
     cd ./out/arm64-v8a
     make
@@ -86,10 +87,9 @@ function remove_temp_dir()
     fi
 }
 
-
-
 show_pwd
 check_and_download_ndk
+check_qnn_sdk
 dump_vars
 remove_temp_dir
 build_arm64

--- a/core/ggml/llamacpp/tests/ggml-qnn/run-ggml-qnn.sh
+++ b/core/ggml/llamacpp/tests/ggml-qnn/run-ggml-qnn.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
-#modify following line to adapt to local dev envs
 #https://qpm.qualcomm.com/#/main/tools/details/qualcomm_ai_engine_direct
 #https://developer.qualcomm.com/software/hexagon-dsp-sdk/tools
 QNN_SDK_PATH=/opt/qcom/aistack/qnn/2.20.0.240223/
-
 GGML_QNN_TEST=ggml-qnn-test
 REMOTE_PATH=/data/local/tmp/
+
+function check_qnn_sdk()
+{
+    if [ ! -d ${QNN_SDK_PATH} ]; then
+        echo -e "QNN_SDK_PATH ${QNN_SDK_PATH} not exist, pls check...\n"
+        exit 1
+    fi
+}
+
+check_qnn_sdk
 
 adb push ${GGML_QNN_TEST} ${REMOTE_PATH}
 
@@ -18,7 +26,7 @@ else
     adb push ${QNN_SDK_PATH}/lib/aarch64-android/libQnnCpu.so                 ${REMOTE_PATH}/
     adb push ${QNN_SDK_PATH}/lib/aarch64-android/libQnnGpu.so                 ${REMOTE_PATH}/
 
-    #the QNN HTP(aka DSP) backend only verified on Xiaomi14(Qualcomm SM8650-AB Snapdragon 8 Gen 3) successfully
+    #the QNN NPU(aka HTP/DSP) backend only verified on Xiaomi14(Qualcomm SM8650-AB Snapdragon 8 Gen 3) successfully
     adb push ${QNN_SDK_PATH}/lib/aarch64-android/libQnnHtp.so                 ${REMOTE_PATH}/
     adb push ${QNN_SDK_PATH}/lib/aarch64-android/libQnnHtpNetRunExtensions.so ${REMOTE_PATH}/
     adb push ${QNN_SDK_PATH}/lib/aarch64-android/libQnnHtpPrepare.so          ${REMOTE_PATH}/
@@ -26,5 +34,6 @@ else
     adb push ${QNN_SDK_PATH}/lib/hexagon-v75/unsigned/libQnnHtpV75Skel.so     ${REMOTE_PATH}/
 fi
 
-adb shell chmod +x /data/local/tmp/${GGML_QNN_TEST}
-adb shell /data/local/tmp/${GGML_QNN_TEST}
+adb shell chmod +x ${REMOTE_PATH}/${GGML_QNN_TEST}
+#adb shell ${REMOTE_PATH}/${GGML_QNN_TEST}
+adb shell ${REMOTE_PATH}/${GGML_QNN_TEST} perf

--- a/core/ggml/whispercpp/whisper.cpp
+++ b/core/ggml/whispercpp/whisper.cpp
@@ -1280,7 +1280,7 @@ static ggml_backend_t whisper_backend_init(const whisper_context_params & params
 #ifdef GGML_USE_QNN
     WHISPER_LOG_INFO("use_gpu %d", params.use_gpu);
     if (params.use_gpu) {
-        if (params.gpu_device != GGML_BACKEND_GGML) { // GGML_BACKEND_GGML is "fake" QNN backend, just used for compare performance between QNN backend and original GGML
+        if (params.gpu_device != QNN_BACKEND_GGML) { // QNN_BACKEND_GGML is "fake" QNN backend, just used for compare performance between QNN backend and original GGML
             WHISPER_LOG_INFO("%s: using QNN backend\n", __func__);
             backend_gpu = ggml_backend_qnn_init(params.gpu_device, "/data/data/com.cdeos.kantv/qnnlib/");// the second param can be got by JNI from Java layer
             if (!backend_gpu) {


### PR DESCRIPTION
validated on Xiaomi 14(a Qualcomm Snapdragon 8 Gen 3 mobile SoC based Android phone) with following cases:

mulmat with QNN CPU/GPU/NPU backend along different threads(1-8)

qnn-auto-ut(add, mulmat) with QNN CPU/GPU/NPU backend along different threads(1-8). there is a bug in automation test of GGML mul OP.

whispercpp inference with QNN CPU/GPU/NPU backend along different threads(1-8)

llamacpp inference with QNN CPU/GPU/NPU backend along different threads(1-8)


all above testcases works fine as expected