### PR TITLE
fix:adb install failed to extract native libraries

### DIFF
--- a/cdeosplayer/kantv/build.gradle
+++ b/cdeosplayer/kantv/build.gradle
@@ -30,6 +30,11 @@ android {
 
         //fix conflict between open source native libs and prebuilt proprietary native libs(IDE would complain more than one file was found)
         packagingOptions {
+            //native libs packing,leagcy mode is used for better compatibility
+            jniLibs {
+                useLegacyPackaging = true
+            }
+        
             pickFirst 'lib/arm64-v8a/libkantv-media.so'
             //pickFirst 'lib/arm64-v8a/libkantv-ffmpeg.so'
             pickFirst 'lib/arm64-v8a/libggml-jni.so'


### PR DESCRIPTION
Hello zhouwg,nice to meet u here.     
I have followed your instructions to build the apk but when I tried to use adb to install it in my phone Redmi Note 11 Pro,I got this error:  
```  
E:\franzkafkayu>adb install kantv-1.0.0-signed.apk
Performing Streamed Install
adb: failed to install kantv-1.0.0-signed.apk: Failure [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]
```    
I have found that this issue is caused by `agp` packing native libraries when `agp` is greater than 7.x,soit’s recommended to adjust the packing options for native libraries for better compatibility.