### PR TITLE
ggml-hexagon: sync ggml-hexagon from project ggml-hexagon

### DIFF
--- a/android/kantvplayer/src/main/assets/models/ggml-hexagon.cfg
+++ b/android/kantvplayer/src/main/assets/models/ggml-hexagon.cfg
@@ -1,6 +1,6 @@
 [general]
 #version of ggml-hexagon.cpp on ARM-AP side
-version = "1.08"
+version = "1.09"
 #version of ggml-dsp.c on cDSP side
 ggmldsp_version = "0.63"
 

--- a/core/ggml/jni/ggml-jni-context.cpp
+++ b/core/ggml/jni/ggml-jni-context.cpp
@@ -352,6 +352,10 @@ const char * ggml_backend_hexagon_get_devname(size_t dev_num) {
             return "unknown";
     }
 }
+
+void set_hexagon_cfg(int new_hexagon_backend, int new_hwaccel_approach) {
+
+}
 #endif
 
 /**

--- a/core/ggml/jni/ggml-jni.h
+++ b/core/ggml/jni/ggml-jni.h
@@ -38,16 +38,6 @@ enum ggml_jni_bench_type {
     GGML_BENCHMARK_TEXT2IMAGE,                //Text2Image benchmark through stablediffusion.cpp
     GGML_BENCHMARK_MAX
 };
-
-//keep sync with ggml-hexagon.cpp
-//0: general approach through QNN:offload ggmlop to QNN
-//1: special approach through QNN-SINGLEGRAPH:mapping entire ggml cgraph to a single QNN graph
-//2: general approach through Hexagon cDSP:offload ggmlop to Hexagon cDSP directly
-enum hwaccel_approach_type {
-    HWACCEL_QNN                     = 0,
-    HWACCEL_QNN_SINGLEGRAPH         = 1,
-    HWACCEL_CDSP                    = 2,
-};
 //=============================================================================================
 
 

--- a/core/ggml/llamacpp/ggml/include/ggml-hexagon.h
+++ b/core/ggml/llamacpp/ggml/include/ggml-hexagon.h
@@ -21,6 +21,15 @@ enum HEXAGONBackend {
     HEXAGON_BACKEND_GGML    = 4, //"fake" HEXAGON backend for compare performance between HEXAGON backend and ggml backend
 };
 
+//0: general approach through QNN:offload ggmlop to QNN(QNNCPU, QNNGPU, QNNNPU）
+//1: special approach through QNN-SINGLEGRAPH:mapping entire ggml cgraph to a single QNN graph
+//2: general approach through Hexagon cDSP:offload ggmlop to Hexagon cDSP directly
+enum hwaccel_approach_type {
+     HWACCEL_QNN            = 0,
+     HWACCEL_QNN_SINGLEGRAPH= 1,
+     HWACCEL_CDSP           = 2,
+};
+
 GGML_BACKEND_API ggml_backend_t ggml_backend_hexagon_init(size_t dev_num, const char * qnn_lib_path);
 
 GGML_BACKEND_API bool           ggml_backend_is_hexagon(ggml_backend_t backend);
@@ -30,6 +39,8 @@ GGML_BACKEND_API int            ggml_backend_hexagon_get_device_count(void);
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_hexagon_reg(void);
 
 const char * ggml_backend_hexagon_get_devname(size_t dev_num);
+
+void set_hexagon_cfg(int new_hexagon_backend, int new_hwaccel_approach);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Purpose
sync ggml-hexagon from project ggml-hexagon: add API set_hexagon_cfg(int new_hexagon_backend, int new_hwaccel_approach) in ggml-hexagon.h & ggml-hexagon.cpp for further usage/purpose.